### PR TITLE
fix(snapshot): resolve default --dest-dir from CWD, not source parent

### DIFF
--- a/jsonl_snapshot/jsonl_snapshot.py
+++ b/jsonl_snapshot/jsonl_snapshot.py
@@ -352,8 +352,16 @@ def _read_sidecar_raw_sha(backup_gz: Path) -> Optional[str]:
 # =============================================================================
 
 
-def _resolve_default_dest_dir(start: Optional[Path]) -> Path:
-    root = find_git_root(start)
+def _resolve_default_dest_dir() -> Path:
+    """Return ``<git-root>/backup/sessions/raw/`` for the caller's CWD.
+
+    Intentionally uses the current working directory, NOT the source
+    jsonl's parent directory. Session jsonls live in
+    ``~/.claude/projects/<proj>/`` which is never a git repo; the
+    destination should land in the repository the user is *currently
+    working in*, which is their CWD.
+    """
+    root = find_git_root()
     return root / DEFAULT_DEST_SUBPATH
 
 
@@ -465,7 +473,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 print(f"error: --source is not a file: {source}", file=sys.stderr)
                 return 2
             if effective_dest is None:
-                effective_dest = _resolve_default_dest_dir(source.parent)
+                effective_dest = _resolve_default_dest_dir()
             request = SnapshotRequest(
                 source=source,
                 dest_dir=effective_dest.expanduser().resolve(),

--- a/session_snapshot/session_snapshot.py
+++ b/session_snapshot/session_snapshot.py
@@ -233,9 +233,17 @@ def restore_snapshot(request: RestoreRequest) -> RestoreResult:
 # =============================================================================
 
 
-def _resolve_default_dest_dir(start: Optional[Path]) -> Path:
-    """Return ``<git-root>/backup/sessions/`` for the caller's CWD."""
-    root = find_git_root(start)
+def _resolve_default_dest_dir() -> Path:
+    """Return ``<git-root>/backup/sessions/`` for the caller's CWD.
+
+    Intentionally uses the current working directory, NOT the source
+    file's parent directory. A typical source file lives in
+    ``~/.claude/projects/<proj>/memory/`` which is never itself
+    inside a git repository; the destination should land in the
+    repository the user is *currently working in*, which is their
+    CWD.
+    """
+    root = find_git_root()
     return root / DEFAULT_DEST_SUBPATH
 
 
@@ -330,7 +338,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 print(f"error: --source is not a file: {source}", file=sys.stderr)
                 return 2
             if effective_dest is None:
-                effective_dest = _resolve_default_dest_dir(source.parent)
+                effective_dest = _resolve_default_dest_dir()
             request = SnapshotRequest(
                 source=source,
                 dest_dir=effective_dest.expanduser().resolve(),


### PR DESCRIPTION
## Summary

First real use of \`session_snapshot\` against an actual astfmt memory file caught a bug in default \`--dest-dir\` resolution: the git-root lookup was starting from the source file's parent directory, but memory files live in \`~/.claude/projects/<proj>/memory/\` which is never itself a git repository. So the lookup was always going to fail for real workloads, falling through to exit code 3 unless the user passed \`--dest-dir\` explicitly.

The intent was always "the git repository the user is currently working in" — their CWD, not the source location. Fix is to drop the explicit \`start\` parameter and let \`find_git_root\` default to \`Path.cwd()\`, matching git's own CLI convention.

Both scripts had the same bug (copy-paste). Both fixed in this PR.

## Repro

Before the fix:

\`\`\`
$ cd /path/to/astfmt
$ python3 -m session_snapshot --source ~/.claude/projects/.../memory/project_session_20260413_b1i_a_closed.md
error: no git repository found at or above /Users/mike/.claude/projects/.../memory
hint: run from inside a git repository, or pass --dest-dir explicitly.
$ echo $?
3
\`\`\`

After the fix:

\`\`\`
$ cd /path/to/astfmt
$ python3 -m session_snapshot --source ~/.claude/projects/.../memory/project_session_20260413_b1i_a_closed.md
source:       /Users/mike/.claude/.../project_session_20260413_b1i_a_closed.md
destination:  /Users/mike/Ada/github.com/abitofhelp/astfmt/backup/sessions/20260415T003738Z__project_session_20260413_b1i_a_closed.md
sha256 src:   2616f69076eeb43c15e0e702f6089cdf9ab1c0c0a7636bdfcd3baef3f3aeb162
sha256 dst:   2616f69076eeb43c15e0e702f6089cdf9ab1c0c0a7636bdfcd3baef3f3aeb162
verified:     OK
\`\`\`

## Why smoke tests in PR #1 missed this

The original smoke tests used fixtures under \`/tmp/ss_test/\` with CWD also under \`/tmp\`. Neither CWD nor source were inside a git repo, so the default-dest-dir path was exercised via the explicit \`--dest-dir\` override instead of the auto-discovery path. The fix adds a docstring on both \`_resolve_default_dest_dir\` functions explaining the CWD intent so the next maintainer does not re-introduce it.

## Test plan

- [x] Manual reproduction before fix: exits 3 with "not in a git repo" error
- [x] Manual verification after fix: exits 0, file lands in \`<cwd-git-root>/backup/sessions/\`
- [x] SHA-256 verified byte-identical
- [x] Both \`session_snapshot\` and \`jsonl_snapshot\` fixed with the same pattern

## Scope

Trivial mechanical fix. No API change. No test suite (the scripts don't have one yet — that would be its own PR).