### PR TITLE
feat(migrate): add migrate_to_backup_sessions rollout helper

### DIFF
--- a/migrate_to_backup_sessions/README.md
+++ b/migrate_to_backup_sessions/README.md
@@ -48,12 +48,24 @@ Given a consumer project git repository, the tool:
    alignment notes or PR review packages worth preserving, others
    are stale scratch that should just be dropped.
 
+8. **Surfaces non-zero-byte non-`.md` tracked files in `exports/`**
+   as **orphans** with a `[WARNING]` banner. **Orphans are
+   intentionally left untouched.** The tool never `git rm`s,
+   `git mv`s, or modifies them in any way. They typically are
+   large old `Claude_Code_Export .txt` transcripts from before
+   the `/export` regression, and their fate (keep as conversation
+   artifact? drop from HEAD? preserve in `backup/sessions/`?)
+   depends on content value only a human can judge. The operator
+   handles them after the tool runs.
+
 Optional mode:
 
 - **`--migrate-all-md`**: also `git mv` every candidate into
   `backup/sessions/` with a UTC-prefixed name derived from the
   candidate's first-commit timestamp. Use this when you want to
-  preserve everything and cherry-pick drops afterward.
+  preserve everything and cherry-pick drops afterward. **Note**:
+  this flag only affects candidates, not orphans — orphans remain
+  intentionally untouched regardless of flags.
 
 The tool **never commits**. All changes are left staged in the
 working tree so the operator can review and commit them as a
@@ -175,12 +187,15 @@ nothing to do; project already conforms.
 - **Does not touch the formal docs, disposition ledger, or any
   Ada/Go/C++ source code.** Migration scope is purely the
   operational directory layout and the submodule pointer.
-- **Does not migrate non-`.md` files from `exports/`**, even if
-  they have content. The candidate list only considers `.md`
-  extensions because that matches the kind of meaningful artifacts
-  the backup convention preserves. Other exports/ content
-  (`.txt` with non-zero bytes, binaries, etc.) stays in place and
-  will become untracked once `exports/` is in `.gitignore`.
+- **Does not touch orphans.** Non-zero-byte non-`.md` tracked files
+  under `exports/` are flagged as orphans and **intentionally left
+  in place**. The `--migrate-all-md` flag does NOT apply to them —
+  orphan handling is always a human decision because their
+  conversation value is something only an operator can judge. If
+  you want to drop them, run `git rm` manually. If you want to
+  preserve them as conversation artifacts, run `git mv` manually
+  into `backup/sessions/` with a UTC-prefixed name. The tool's
+  job is to tell you they exist, not to pick their fate.
 
 ## See also
 

--- a/migrate_to_backup_sessions/README.md
+++ b/migrate_to_backup_sessions/README.md
@@ -1,0 +1,192 @@
+# migrate_to_backup_sessions
+
+One-sentence purpose: **idempotent rollout helper that brings a
+consumer project into conformance with the `backup/sessions/`
+convention defined by `session_snapshot` and `jsonl_snapshot`.**
+
+---
+
+## When to use
+
+- **Once per consumer project** during the initial rollout of the
+  backup/sessions convention.
+- **Anytime later** to re-check a project against the convention —
+  the tool is idempotent, so rerunning it on a conforming project
+  is a safe no-op that reports "nothing to do".
+- **After a convention change** — if the target state evolves, a
+  new release of this tool can bring every consumer back into
+  conformance with one command per repo.
+
+This tool is the paired migration helper for the two snapshot
+tools. See
+[`session_snapshot`](../session_snapshot/README.md) and
+[`jsonl_snapshot`](../jsonl_snapshot/README.md) for the backup
+tools themselves.
+
+## What it does
+
+Given a consumer project git repository, the tool:
+
+1. **Creates `backup/sessions/`** if missing.
+2. **Writes `backup/sessions/README.md`** from an embedded template
+   that documents the convention (project-agnostic, no name
+   substitution needed).
+3. **Writes `backup/sessions/raw/.gitignore`** so the `raw/`
+   subdirectory is tracked but its contents are ignored.
+4. **Adds `exports/` to the project's root `.gitignore`** with an
+   explanatory comment block. Skipped if `exports/` is already
+   ignored.
+5. **Removes tracked 0-byte `exports/*` files** via `git rm`. These
+   are stubs created by the broken Claude Code `/export` command
+   and have no content.
+6. **Bumps the `scripts/python/shared` submodule pointer** to the
+   target SHA (default: `hybrid_scripts_python` main HEAD at the
+   time this tool shipped). Overridable via `--submodule-ref`.
+7. **Lists non-zero-byte `.md` files in `exports/`** as
+   **candidates** for human review. These are NOT migrated by
+   default because judgment is required: some are meaningful
+   alignment notes or PR review packages worth preserving, others
+   are stale scratch that should just be dropped.
+
+Optional mode:
+
+- **`--migrate-all-md`**: also `git mv` every candidate into
+  `backup/sessions/` with a UTC-prefixed name derived from the
+  candidate's first-commit timestamp. Use this when you want to
+  preserve everything and cherry-pick drops afterward.
+
+The tool **never commits**. All changes are left staged in the
+working tree so the operator can review and commit them as a
+single migration commit.
+
+## Idempotency
+
+Every task checks its target before acting:
+
+- Directory creation is `mkdir -p`, harmless if already present.
+- File writes use "write if missing" semantics.
+- `.gitignore` appending checks for the sentinel line first.
+- Submodule pointer is compared against the target SHA before
+  calling `git submodule update --remote`.
+- Zero-byte stub removal walks tracked files and only touches
+  files with `stat().st_size == 0`.
+
+A consumer project that has already been migrated reports
+"nothing to do" on a rerun. A partially migrated project gets
+only the missing pieces applied.
+
+## Filename convention for migrated `.md` files
+
+Matches `session_snapshot` and `jsonl_snapshot`:
+
+```
+<YYYYMMDDTHHMMSSZ>__<original-basename>
+```
+
+The UTC timestamp comes from `git log --diff-filter=A --follow` on
+the candidate file — it is the first commit that added the file to
+the index. Authoritative, unambiguous, and matches the timestamp
+strategy used elsewhere.
+
+Candidates whose first-commit timestamp cannot be resolved (never
+committed, path outside the repo, git history rewritten) are
+**skipped** even in `--migrate-all-md` mode, with an explicit
+"skipped: cannot derive UTC timestamp" message. Those files must
+be moved manually.
+
+## CLI reference
+
+```
+migrate_to_backup_sessions [--project-root DIR]
+                           [--submodule-ref SHA]
+                           [--migrate-all-md]
+                           [--dry-run]
+```
+
+| Flag | Purpose | Default |
+|---|---|---|
+| `--project-root DIR` | Consumer project git root. | `find_git_root(cwd)` |
+| `--submodule-ref SHA` | Target SHA for `scripts/python/shared`. | `hybrid_scripts_python` main HEAD at tool ship time (see `DEFAULT_SUBMODULE_REF` constant) |
+| `--migrate-all-md` | Also `git mv` every non-zero-byte candidate `.md`. | off |
+| `--dry-run` | Report what would happen without writing. | off |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success (either "nothing to do" or changes applied) |
+| 1 | Runtime error (I/O, git subprocess failure, value error) |
+| 2 | Bad argument (invalid `--project-root`) |
+| 3 | Not inside a git repository (no `--project-root` resolvable) |
+
+## Typical workflow
+
+```bash
+# Start in a consumer project worktree
+cd ~/Ada/github.com/abitofhelp/adafmt
+
+# First pass: dry-run to see what will happen
+PYTHONPATH=scripts/python/shared python3 -m migrate_to_backup_sessions --dry-run
+
+# Second pass: apply the mechanical changes
+PYTHONPATH=scripts/python/shared python3 -m migrate_to_backup_sessions
+
+# Review the candidate list (printed at the end of the output):
+#   - Keep the meaningful ones? Rerun with --migrate-all-md
+#   - Drop everything? git rm the candidates manually
+#
+# In this example we keep everything:
+PYTHONPATH=scripts/python/shared python3 -m migrate_to_backup_sessions --migrate-all-md
+
+# Review staged changes and commit
+git status
+git diff --cached
+git commit -m "chore(backup): adopt backup/sessions/ convention"
+git push
+```
+
+Rerunning on a conforming project:
+
+```bash
+$ migrate_to_backup_sessions
+project root:    /Users/mike/Ada/github.com/abitofhelp/adafmt
+target submodule: a3ace7031203
+
+already done:
+  - backup/sessions/ exists
+  - backup/sessions/README.md exists
+  - backup/sessions/raw/.gitignore exists
+  - exports/ already in .gitignore
+  - scripts/python/shared submodule already at a3ace70
+
+planned tasks: none (project already conforms)
+
+non-zero-byte .md candidates: none
+
+nothing to do; project already conforms.
+```
+
+## What this tool does NOT do
+
+- **Does not commit.** Changes are staged and left for human review.
+- **Does not push or open PRs.** That remains a manual step per
+  project so the operator can add project-specific commit message
+  content.
+- **Does not touch the formal docs, disposition ledger, or any
+  Ada/Go/C++ source code.** Migration scope is purely the
+  operational directory layout and the submodule pointer.
+- **Does not migrate non-`.md` files from `exports/`**, even if
+  they have content. The candidate list only considers `.md`
+  extensions because that matches the kind of meaningful artifacts
+  the backup convention preserves. Other exports/ content
+  (`.txt` with non-zero bytes, binaries, etc.) stays in place and
+  will become untracked once `exports/` is in `.gitignore`.
+
+## See also
+
+- [`session_snapshot`](../session_snapshot/README.md) — strategic
+  memory-file backup tool
+- [`jsonl_snapshot`](../jsonl_snapshot/README.md) — forensic
+  session-jsonl backup tool
+- `backup/sessions/README.md` in any migrated consumer — same
+  convention documentation, embedded by this tool during rollout

--- a/migrate_to_backup_sessions/__init__.py
+++ b/migrate_to_backup_sessions/__init__.py
@@ -1,0 +1,42 @@
+# ==============================================================================
+# migrate_to_backup_sessions/__init__.py - Rollout helper for backup/sessions
+# ==============================================================================
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+# ==============================================================================
+
+"""
+migrate_to_backup_sessions - Idempotent rollout helper that brings a
+consumer project into conformance with the backup/sessions/
+convention. See README.md in this directory for the full story.
+"""
+
+from .migrate_to_backup_sessions import (
+    DEFAULT_SUBMODULE_REF,
+    build_plan,
+    execute_plan,
+    main,
+)
+from .models import (
+    Candidate,
+    MigrationPlan,
+    MigrationResult,
+    Task,
+    TaskKind,
+    TaskOutcome,
+)
+
+__all__ = [
+    "Candidate",
+    "DEFAULT_SUBMODULE_REF",
+    "MigrationPlan",
+    "MigrationResult",
+    "Task",
+    "TaskKind",
+    "TaskOutcome",
+    "build_plan",
+    "execute_plan",
+    "main",
+]
+
+__version__ = "1.0.0"

--- a/migrate_to_backup_sessions/__main__.py
+++ b/migrate_to_backup_sessions/__main__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# migrate_to_backup_sessions/__main__.py - Module entry point
+# ==============================================================================
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+# ==============================================================================
+
+"""Entry point for running ``python -m migrate_to_backup_sessions``."""
+
+from .migrate_to_backup_sessions import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migrate_to_backup_sessions/adapters/__init__.py
+++ b/migrate_to_backup_sessions/adapters/__init__.py
@@ -1,0 +1,6 @@
+# ==============================================================================
+# adapters/__init__.py - Infrastructure adapters for migrate_to_backup_sessions
+# ==============================================================================
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+# ==============================================================================

--- a/migrate_to_backup_sessions/adapters/filesystem.py
+++ b/migrate_to_backup_sessions/adapters/filesystem.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# adapters/filesystem.py - Filesystem operations for the migration tool
+# ==============================================================================
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+# See LICENSE file in the project root.
+# ==============================================================================
+
+from pathlib import Path
+from typing import List
+
+
+def ensure_dir(path: Path) -> None:
+    """Create ``path`` and any missing parents."""
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def write_text_if_missing(path: Path, content: str) -> bool:
+    """Write ``content`` to ``path`` only if the file does not exist.
+
+    Returns True if a write happened, False if the path already
+    existed (idempotency: leave existing content alone).
+    """
+    if path.exists():
+        return False
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def file_size(path: Path) -> int:
+    """Return file size in bytes, or -1 if the path cannot be stat'd."""
+    try:
+        return path.stat().st_size
+    except OSError:
+        return -1
+
+
+def list_files_under(directory: Path, suffix: str = "") -> List[Path]:
+    """Return all regular files directly under ``directory``.
+
+    Non-recursive. Filters by suffix if provided (e.g. ``.md``).
+    """
+    if not directory.is_dir():
+        return []
+    result: List[Path] = []
+    for entry in sorted(directory.iterdir()):
+        if not entry.is_file():
+            continue
+        if suffix and not entry.name.endswith(suffix):
+            continue
+        result.append(entry)
+    return result
+
+
+def append_lines_if_missing(path: Path, block: str) -> bool:
+    """Append ``block`` to ``path`` if its contents do not already contain it.
+
+    Idempotency primitive used for .gitignore updates: check for a
+    sentinel substring (the non-comment line that actually matches
+    files) before writing, so rerunning the tool is a no-op.
+
+    Args:
+        path: File to check/append.
+        block: Multi-line string to append if the sentinel is missing.
+               The sentinel is any non-empty, non-comment line in block.
+
+    Returns True if the block was appended, False if it was already
+    present (or the file could not be created for some reason).
+    """
+    # Identify the sentinel: the first non-comment, non-empty line.
+    sentinel = ""
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            sentinel = stripped
+            break
+    if not sentinel:
+        return False
+
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    for line in existing.splitlines():
+        if line.strip() == sentinel:
+            return False
+
+    ensure_dir(path.parent)
+    with path.open("a", encoding="utf-8") as f:
+        if existing and not existing.endswith("\n"):
+            f.write("\n")
+        f.write(block.rstrip("\n") + "\n")
+    return True

--- a/migrate_to_backup_sessions/adapters/git_ops.py
+++ b/migrate_to_backup_sessions/adapters/git_ops.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# adapters/git_ops.py - git subprocess operations
+# ==============================================================================
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+# See LICENSE file in the project root.
+#
+# Purpose:
+#   All git subprocess calls the migration tool makes go through this
+#   adapter so the orchestration layer never calls subprocess directly.
+#   Keeps the main script testable by faking this module.
+# ==============================================================================
+
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+def _run(cmd: List[str], cwd: Optional[Path] = None) -> str:
+    """Run a git command and return its stdout, raising on non-zero exit."""
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout
+
+
+def is_tracked(path: Path, repo: Path) -> bool:
+    """Return True if ``path`` is tracked in the repo's index."""
+    try:
+        _run(
+            ["git", "-C", str(repo), "ls-files", "--error-unmatch", str(path.relative_to(repo))],
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def list_tracked_under(directory: Path, repo: Path) -> List[Path]:
+    """Return all tracked files directly under ``directory`` (non-recursive)."""
+    rel = str(directory.relative_to(repo))
+    try:
+        stdout = _run(["git", "-C", str(repo), "ls-files", rel])
+    except subprocess.CalledProcessError:
+        return []
+    result: List[Path] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        result.append(repo / line)
+    return result
+
+
+def git_rm(path: Path, repo: Path) -> None:
+    """Run ``git rm`` on a single file inside ``repo``."""
+    _run(["git", "-C", str(repo), "rm", str(path.relative_to(repo))])
+
+
+def git_mv(source: Path, destination: Path, repo: Path) -> None:
+    """Run ``git mv`` from source to destination inside ``repo``.
+
+    Both paths must be within the repo. Destination parent directory
+    must already exist (``mkdir -p`` is the caller's responsibility).
+    """
+    _run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "mv",
+            str(source.relative_to(repo)),
+            str(destination.relative_to(repo)),
+        ]
+    )
+
+
+def first_commit_timestamp_utc(file_path: Path, repo: Path) -> Tuple[Optional[str], Optional[str]]:
+    """Return (commit_sha, UTC timestamp in YYYYMMDDTHHMMSSZ) for the commit
+    that first added ``file_path`` to the index.
+
+    Returns (None, None) if no such commit is found (file never committed
+    or path outside the repo).
+    """
+    try:
+        rel = str(file_path.relative_to(repo))
+    except ValueError:
+        return (None, None)
+    try:
+        out = _run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "log",
+                "--all",
+                "--diff-filter=A",
+                "--pretty=format:%H %cI",
+                "--follow",
+                "--",
+                rel,
+            ]
+        )
+    except subprocess.CalledProcessError:
+        return (None, None)
+    first_line = out.strip().splitlines()[0] if out.strip() else ""
+    if not first_line:
+        return (None, None)
+    parts = first_line.split(maxsplit=1)
+    if len(parts) != 2:
+        return (None, None)
+    sha, iso = parts
+    # ISO 8601 with timezone to compact UTC form.
+    # Example: "2026-04-13T20:42:28-07:00" -> "20260414T034228Z"
+    try:
+        from datetime import datetime, timezone
+        dt = datetime.fromisoformat(iso)
+        dt_utc = dt.astimezone(timezone.utc)
+        compact = dt_utc.strftime("%Y%m%dT%H%M%SZ")
+    except (ValueError, AttributeError):
+        return (sha, None)
+    return (sha, compact)
+
+
+def submodule_update_remote(submodule_path: Path, repo: Path) -> str:
+    """Run ``git submodule update --remote`` on a single submodule.
+
+    Returns the resulting HEAD SHA of the submodule after the update,
+    or the empty string if the SHA could not be read.
+    """
+    _run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "submodule",
+            "update",
+            "--remote",
+            str(submodule_path.relative_to(repo)),
+        ]
+    )
+    try:
+        out = _run(
+            ["git", "-C", str(repo / submodule_path.relative_to(repo)), "rev-parse", "HEAD"]
+        )
+        return out.strip()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def current_submodule_sha(submodule_path: Path, repo: Path) -> Optional[str]:
+    """Return the SHA the superproject's index currently tracks for the submodule.
+
+    Uses ``git ls-tree HEAD`` so it reflects the committed pointer, not
+    the working-tree state.
+    """
+    try:
+        out = _run(
+            [
+                "git",
+                "-C",
+                str(repo),
+                "ls-tree",
+                "HEAD",
+                str(submodule_path.relative_to(repo)),
+            ]
+        )
+    except subprocess.CalledProcessError:
+        return None
+    parts = out.split()
+    if len(parts) >= 3 and parts[1] == "commit":
+        return parts[2]
+    return None

--- a/migrate_to_backup_sessions/adapters/git_root.py
+++ b/migrate_to_backup_sessions/adapters/git_root.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# adapters/git_root.py - git repository root discovery
+# ==============================================================================
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+# See LICENSE file in the project root.
+# ==============================================================================
+
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+class NotInsideGitRepositoryError(RuntimeError):
+    """Raised when no git repository is found at or above the start directory."""
+
+
+def find_git_root(start: Optional[Path] = None) -> Path:
+    """Return the absolute path of the git repository containing ``start``.
+
+    Duplicated from session_snapshot/adapters/git_root.py so this
+    script remains self-contained and can be invoked independently.
+    """
+    if start is None:
+        start = Path.cwd()
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise NotInsideGitRepositoryError(
+            f"no git repository found at or above {start}: "
+            f"{exc.stderr.strip() or 'git rev-parse --show-toplevel failed'}"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise NotInsideGitRepositoryError(
+            "git executable not found on PATH"
+        ) from exc
+    return Path(proc.stdout.strip()).resolve()

--- a/migrate_to_backup_sessions/migrate_to_backup_sessions.py
+++ b/migrate_to_backup_sessions/migrate_to_backup_sessions.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# migrate_to_backup_sessions.py - Roll out the backup/sessions convention
+# ==============================================================================
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+# See LICENSE file in the project root.
+#
+# Purpose:
+#   Idempotently bring a consumer project into conformance with the
+#   backup/sessions/ convention defined by session_snapshot and
+#   jsonl_snapshot. See README.md in this directory for the full
+#   contract and the "how to use across projects" walkthrough.
+# ==============================================================================
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+try:
+    from .models import (
+        Candidate,
+        MigrationPlan,
+        MigrationResult,
+        OrphanTrackedExport,
+        Task,
+        TaskKind,
+        TaskOutcome,
+    )
+    from .adapters.filesystem import (
+        append_lines_if_missing,
+        ensure_dir,
+        file_size,
+        list_files_under,
+        write_text_if_missing,
+    )
+    from .adapters.git_ops import (
+        current_submodule_sha,
+        first_commit_timestamp_utc,
+        git_mv,
+        git_rm,
+        is_tracked,
+        list_tracked_under,
+        submodule_update_remote,
+    )
+    from .adapters.git_root import NotInsideGitRepositoryError, find_git_root
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from migrate_to_backup_sessions.models import (  # type: ignore
+        Candidate,
+        MigrationPlan,
+        MigrationResult,
+        OrphanTrackedExport,
+        Task,
+        TaskKind,
+        TaskOutcome,
+    )
+    from migrate_to_backup_sessions.adapters.filesystem import (  # type: ignore
+        append_lines_if_missing,
+        ensure_dir,
+        file_size,
+        list_files_under,
+        write_text_if_missing,
+    )
+    from migrate_to_backup_sessions.adapters.git_ops import (  # type: ignore
+        current_submodule_sha,
+        first_commit_timestamp_utc,
+        git_mv,
+        git_rm,
+        is_tracked,
+        list_tracked_under,
+        submodule_update_remote,
+    )
+    from migrate_to_backup_sessions.adapters.git_root import (  # type: ignore
+        NotInsideGitRepositoryError,
+        find_git_root,
+    )
+
+
+# The shared submodule that holds session_snapshot / jsonl_snapshot.
+# Consumers mount it at this path by convention.
+SUBMODULE_REL_PATH = Path("scripts") / "python" / "shared"
+
+# Target state in each consumer after migration.
+BACKUP_DIR_REL = Path("backup") / "sessions"
+RAW_DIR_REL = BACKUP_DIR_REL / "raw"
+
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+#
+# Kept inline rather than in separate files so the entire tool stays a
+# single Python package with no external asset loading. The text is
+# project-agnostic and does not reference any specific project name.
+
+
+BACKUP_SESSIONS_README = """\
+# backup/sessions/
+
+Durable, git-tracked archive of session artifacts for this project.
+
+## What lives here
+
+Three kinds of files, all using the same filename convention so
+chronological sort works across kinds:
+
+```
+<YYYYMMDDTHHMMSSZ>__<original-basename>
+```
+
+| Kind | How it gets here | Source of the content |
+|---|---|---|
+| `*_alignment_note.md` | Written directly by the assistant when a slice opens with a design decision. Committed with the slice's first commit. | The assistant's pre-coding review of the frozen docs + GPT check. |
+| `*_pr_review_package.md` | Written directly by the assistant before a PR is opened. Committed with the slice's PR. | The assistant's self-contained review document for GPT. |
+| `*` (time-driven snapshots) | Mirrored here by `scripts/python/shared/session_snapshot`, typically via the `/snapshot` custom slash command. | A Claude Code memory file from `~/.claude/projects/<encoded-project>/memory/`, preserved verbatim after the `<timestamp>__` prefix. |
+
+Filenames sort naturally by UTC timestamp regardless of how many
+different kinds coexist in the directory. Recovery of any file is a
+plain `cp` with prefix strip (see
+`scripts/python/shared/session_snapshot/README.md` for the
+`--restore` tool or the manual procedure).
+
+## Relationship to `backup/sessions/raw/`
+
+`raw/` is **gitignored** and holds compressed full-session `.jsonl`
+backups produced by `scripts/python/shared/jsonl_snapshot`. Those
+files are large (~10 MB per snapshot) and intended for external
+storage. Git-tracked files stay up here in `backup/sessions/`.
+
+See `scripts/python/shared/jsonl_snapshot/README.md` for the full
+forensic-tier workflow.
+
+## What this is NOT
+
+- **Not the Claude Code `/export` command output.** The CLI
+  `/export` has been broken for some time; this directory is the
+  workflow that replaces it.
+- **Not a full conversation transcript.** Memory files are
+  curated recap summaries written by the assistant at key
+  workflow points. Use `jsonl_snapshot` and the raw session
+  `.jsonl` under `~/.claude/projects/.../<uuid>.jsonl` for
+  forensic recovery of verbatim conversation content.
+- **Not a replacement for the Claude Code memory system.**
+  Memory files in `~/.claude/projects/.../memory/` remain the
+  auto-loaded source of strategic context at session start.
+  This directory is the off-machine-durable backup copy that
+  survives a local-state loss.
+"""
+
+
+RAW_GITIGNORE_CONTENT = """\
+# Everything in this directory is gitignored on purpose: compressed
+# session jsonls are large binary blobs that belong on external
+# storage, not in git history. The directory itself is tracked
+# (via this .gitignore file being the only tracked file) so fresh
+# clones get a usable target for jsonl_snapshot without needing to
+# run mkdir.
+#
+# See ../README.md and scripts/python/shared/jsonl_snapshot/README.md
+# for the workflow that targets this directory.
+
+*
+!.gitignore
+"""
+
+
+EXPORTS_GITIGNORE_BLOCK = """\
+# Claude Code session exports / ephemeral scratch space.
+# The CLI /export command has been broken for some time (writes
+# 0-byte stubs); durable session artifacts now live in
+# backup/sessions/ via the session_snapshot tool in
+# scripts/python/shared. The exports/ directory is kept as a local
+# scratch path for cross-project context bouncing, but its contents
+# are not git-tracked. See backup/sessions/README.md.
+exports/
+"""
+
+
+# ---------------------------------------------------------------------------
+# Planning
+# ---------------------------------------------------------------------------
+
+
+def build_plan(project_root: Path, submodule_ref_target: str) -> MigrationPlan:
+    """Inspect ``project_root`` and compute the work needed.
+
+    The returned plan is exhaustive for the mechanical tasks. Any
+    non-zero-byte .md file in exports/ is reported as a Candidate
+    (not a Task) — the caller decides whether to migrate them.
+    """
+    tasks: List[Task] = []
+    already_done: List[str] = []
+    candidates: List[Candidate] = []
+    orphans: List[OrphanTrackedExport] = []
+
+    backup_dir = project_root / BACKUP_DIR_REL
+    backup_readme = backup_dir / "README.md"
+    raw_dir = project_root / RAW_DIR_REL
+    raw_gitignore = raw_dir / ".gitignore"
+    root_gitignore = project_root / ".gitignore"
+    exports_dir = project_root / "exports"
+
+    # 1. backup/sessions/ directory + README
+    if not backup_dir.is_dir():
+        tasks.append(
+            Task(
+                kind=TaskKind.CREATE_BACKUP_SESSIONS_DIR,
+                target=backup_dir,
+                detail="create backup/sessions/ directory",
+            )
+        )
+    else:
+        already_done.append("backup/sessions/ exists")
+
+    if not backup_readme.is_file():
+        tasks.append(
+            Task(
+                kind=TaskKind.CREATE_BACKUP_SESSIONS_README,
+                target=backup_readme,
+                detail="write backup/sessions/README.md",
+            )
+        )
+    else:
+        already_done.append("backup/sessions/README.md exists")
+
+    # 2. backup/sessions/raw/.gitignore
+    if not raw_gitignore.is_file():
+        tasks.append(
+            Task(
+                kind=TaskKind.CREATE_RAW_GITIGNORE,
+                target=raw_gitignore,
+                detail="write backup/sessions/raw/.gitignore",
+            )
+        )
+    else:
+        already_done.append("backup/sessions/raw/.gitignore exists")
+
+    # 3. Add exports/ to .gitignore
+    existing_root_gitignore = (
+        root_gitignore.read_text(encoding="utf-8")
+        if root_gitignore.is_file()
+        else ""
+    )
+    if "exports/" not in existing_root_gitignore.splitlines():
+        tasks.append(
+            Task(
+                kind=TaskKind.ADD_EXPORTS_TO_GITIGNORE,
+                target=root_gitignore,
+                detail="add exports/ entry to root .gitignore",
+            )
+        )
+    else:
+        already_done.append("exports/ already in .gitignore")
+
+    # 4. Classify tracked files under exports/:
+    #    - 0 bytes  -> auto-remove task (safe, no content loss)
+    #    - .md file -> migration candidate (human review; optionally
+    #                  auto-migrate via --migrate-all-md)
+    #    - other    -> orphan (human review; NOT auto-handled because
+    #                  they typically have real content of uncertain
+    #                  value — e.g., large .txt Claude_Code_Export
+    #                  transcripts from before the /export regression —
+    #                  and the operator must decide git rm vs manual
+    #                  migration)
+    tracked_exports = list_tracked_under(exports_dir, project_root) if exports_dir.is_dir() else []
+    for tracked in tracked_exports:
+        size = file_size(tracked)
+        if size == 0:
+            tasks.append(
+                Task(
+                    kind=TaskKind.REMOVE_ZERO_BYTE_EXPORT,
+                    target=tracked,
+                    detail=f"git rm {tracked.relative_to(project_root)} (0 bytes)",
+                )
+            )
+        elif tracked.suffix == ".md":
+            sha, ts = first_commit_timestamp_utc(tracked, project_root)
+            timestamp_part = ts if ts else "UNKNOWN"
+            target_name = f"{timestamp_part}__{tracked.name}"
+            candidates.append(
+                Candidate(
+                    source=tracked,
+                    size_bytes=size,
+                    commit_sha=sha,
+                    commit_timestamp_utc=ts,
+                    target_name=target_name,
+                )
+            )
+        else:
+            orphans.append(OrphanTrackedExport(source=tracked, size_bytes=size))
+
+    # 5. Submodule pointer bump (always planned; executor decides no-op)
+    current_sha = current_submodule_sha(project_root / SUBMODULE_REL_PATH, project_root)
+    if current_sha != submodule_ref_target:
+        tasks.append(
+            Task(
+                kind=TaskKind.BUMP_SUBMODULE_POINTER,
+                target=project_root / SUBMODULE_REL_PATH,
+                detail=(
+                    f"bump {SUBMODULE_REL_PATH} submodule: "
+                    f"{(current_sha or '<missing>')[:7]} -> {submodule_ref_target[:7]}"
+                ),
+            )
+        )
+    else:
+        already_done.append(
+            f"{SUBMODULE_REL_PATH} submodule already at {submodule_ref_target[:7]}"
+        )
+
+    return MigrationPlan(
+        project_root=project_root,
+        submodule_ref_target=submodule_ref_target,
+        tasks=tasks,
+        candidates=candidates,
+        orphan_tracked_exports=orphans,
+        already_done=already_done,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+
+def execute_plan(
+    plan: MigrationPlan,
+    *,
+    dry_run: bool,
+    migrate_all_md: bool,
+) -> MigrationResult:
+    """Apply ``plan`` to the project.
+
+    If ``migrate_all_md`` is True, every candidate is also moved into
+    backup/sessions/ via ``git mv`` with its UTC-prefixed target name.
+    Candidates without a commit timestamp are skipped with a warning.
+    Nothing is committed; all changes are left staged for human
+    review.
+    """
+    outcomes: List[TaskOutcome] = []
+
+    for task in plan.tasks:
+        outcomes.append(_apply_task(task, plan.project_root, dry_run=dry_run))
+
+    if migrate_all_md:
+        for candidate in plan.candidates:
+            outcomes.append(
+                _apply_candidate(candidate, plan.project_root, dry_run=dry_run)
+            )
+
+    return MigrationResult(plan=plan, outcomes=outcomes, dry_run=dry_run)
+
+
+def _apply_task(task: Task, repo: Path, *, dry_run: bool) -> TaskOutcome:
+    """Dispatch a single Task to the appropriate adapter call."""
+    if dry_run:
+        return TaskOutcome(task=task, applied=False, message=f"would: {task.detail}")
+
+    if task.kind == TaskKind.CREATE_BACKUP_SESSIONS_DIR:
+        ensure_dir(task.target)
+        return TaskOutcome(task=task, applied=True, message=f"created {task.target.relative_to(repo)}")
+
+    if task.kind == TaskKind.CREATE_BACKUP_SESSIONS_README:
+        ensure_dir(task.target.parent)
+        wrote = write_text_if_missing(task.target, BACKUP_SESSIONS_README)
+        return TaskOutcome(
+            task=task,
+            applied=wrote,
+            message=(
+                f"wrote {task.target.relative_to(repo)}"
+                if wrote
+                else "already present"
+            ),
+        )
+
+    if task.kind == TaskKind.CREATE_RAW_GITIGNORE:
+        ensure_dir(task.target.parent)
+        wrote = write_text_if_missing(task.target, RAW_GITIGNORE_CONTENT)
+        return TaskOutcome(
+            task=task,
+            applied=wrote,
+            message=(
+                f"wrote {task.target.relative_to(repo)}"
+                if wrote
+                else "already present"
+            ),
+        )
+
+    if task.kind == TaskKind.ADD_EXPORTS_TO_GITIGNORE:
+        appended = append_lines_if_missing(task.target, EXPORTS_GITIGNORE_BLOCK)
+        return TaskOutcome(
+            task=task,
+            applied=appended,
+            message=(
+                "appended exports/ block"
+                if appended
+                else "exports/ already ignored"
+            ),
+        )
+
+    if task.kind == TaskKind.REMOVE_ZERO_BYTE_EXPORT:
+        git_rm(task.target, repo)
+        return TaskOutcome(
+            task=task,
+            applied=True,
+            message=f"git rm {task.target.relative_to(repo)}",
+        )
+
+    if task.kind == TaskKind.BUMP_SUBMODULE_POINTER:
+        new_sha = submodule_update_remote(task.target, repo)
+        return TaskOutcome(
+            task=task,
+            applied=True,
+            message=f"submodule updated to {new_sha[:7] if new_sha else '<unknown>'}",
+        )
+
+    return TaskOutcome(
+        task=task, applied=False, message=f"unknown task kind: {task.kind}"
+    )
+
+
+def _apply_candidate(candidate: Candidate, repo: Path, *, dry_run: bool) -> TaskOutcome:
+    """Migrate a candidate .md file into backup/sessions/ via git mv."""
+    if candidate.commit_timestamp_utc is None:
+        return TaskOutcome(
+            task=Task(
+                kind=TaskKind.MIGRATE_MEANINGFUL_MD,
+                target=candidate.source,
+                detail=f"migrate {candidate.source.name} (no commit timestamp)",
+            ),
+            applied=False,
+            message=(
+                "skipped: cannot derive UTC timestamp from git history "
+                "(file never committed or outside repo)"
+            ),
+        )
+
+    destination = repo / BACKUP_DIR_REL / candidate.target_name
+    task = Task(
+        kind=TaskKind.MIGRATE_MEANINGFUL_MD,
+        target=candidate.source,
+        detail=f"git mv {candidate.source.relative_to(repo)} -> {destination.relative_to(repo)}",
+    )
+    if dry_run:
+        return TaskOutcome(task=task, applied=False, message=f"would: {task.detail}")
+
+    ensure_dir(destination.parent)
+    git_mv(candidate.source, destination, repo)
+    return TaskOutcome(task=task, applied=True, message=task.detail)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+# Default target SHA for the shared submodule. Kept in sync with the
+# current hybrid_scripts_python main HEAD at the time this tool ships.
+# Callers can override with --submodule-ref.
+DEFAULT_SUBMODULE_REF = "a3ace70312030365d51875136890bec9a904fd7e"
+
+
+def _print_plan(plan: MigrationPlan) -> None:
+    print(f"project root:    {plan.project_root}")
+    print(f"target submodule: {plan.submodule_ref_target[:12]}")
+    print()
+    if plan.already_done:
+        print("already done:")
+        for item in plan.already_done:
+            print(f"  - {item}")
+        print()
+    if plan.tasks:
+        print(f"planned tasks ({len(plan.tasks)}):")
+        for task in plan.tasks:
+            print(f"  - [{task.kind.value}] {task.detail}")
+        print()
+    else:
+        print("planned tasks: none (project already conforms)")
+        print()
+    if plan.candidates:
+        print(f"non-zero-byte .md candidates in exports/ ({len(plan.candidates)}):")
+        for c in plan.candidates:
+            ts = c.commit_timestamp_utc or "UNKNOWN"
+            print(
+                f"  - {c.source.name} ({c.size_bytes} bytes, "
+                f"first-added {ts}) -> {c.target_name}"
+            )
+        print(
+            "  (these are NOT migrated automatically — pass --migrate-all-md "
+            "to move them via git mv)"
+        )
+        print()
+    else:
+        print("non-zero-byte .md candidates: none")
+        print()
+
+    if plan.orphan_tracked_exports:
+        print(
+            f"[WARNING] orphan tracked non-.md files in exports/ "
+            f"({len(plan.orphan_tracked_exports)}):"
+        )
+        for o in plan.orphan_tracked_exports:
+            print(f"  - {o.source.relative_to(plan.project_root)} ({o.size_bytes} bytes)")
+        print(
+            "  These files have real content but are NOT .md artifacts the"
+        )
+        print(
+            "  convention preserves (typically old Claude_Code_Export .txt"
+        )
+        print(
+            "  transcripts). The tool will NOT touch them automatically."
+        )
+        print(
+            "  Adding exports/ to .gitignore does NOT untrack them; they"
+        )
+        print(
+            "  will remain in the git index until you handle them manually:"
+        )
+        print()
+        print(
+            "    option A (usual):  git rm <path>    # drop from HEAD,"
+        )
+        print(
+            "                                        # history preserved"
+        )
+        print(
+            "    option B (rare):   git mv <path> backup/sessions/<utc-prefixed-name>"
+        )
+        print(
+            "                                        # preserve as conversation"
+        )
+        print(
+            "                                        # artifact"
+        )
+        print()
+    else:
+        print("orphan tracked non-.md files in exports/: none")
+        print()
+
+
+def _print_outcomes(result: MigrationResult) -> None:
+    tag = "[DRY-RUN] " if result.dry_run else ""
+    print(f"{tag}execution summary:")
+    if not result.outcomes:
+        print(f"{tag}  (nothing to do)")
+        return
+    for o in result.outcomes:
+        mark = "+" if o.applied else "."
+        print(f"{tag}  {mark} {o.message}")
+    print(
+        f"{tag}applied: {result.applied_count}  skipped/already-done: "
+        f"{result.skipped_count}"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="migrate_to_backup_sessions",
+        description=(
+            "Idempotently bring a consumer project into conformance with "
+            "the backup/sessions/ convention: create the tracked "
+            "directories, write the README + raw/.gitignore, add exports/ "
+            "to .gitignore, git rm any tracked 0-byte exports stubs, and "
+            "bump the scripts/python/shared submodule pointer. Leaves "
+            "everything staged for human review; never commits."
+        ),
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=None,
+        help="Project root. Defaults to git root of the current working directory.",
+    )
+    parser.add_argument(
+        "--submodule-ref",
+        default=DEFAULT_SUBMODULE_REF,
+        help=f"Target SHA for the scripts/python/shared submodule pointer. "
+        f"Default: {DEFAULT_SUBMODULE_REF[:12]} (hybrid_scripts_python main).",
+    )
+    parser.add_argument(
+        "--migrate-all-md",
+        action="store_true",
+        help="Also git mv every non-zero-byte .md file in exports/ into "
+        "backup/sessions/ using its first-commit UTC timestamp. Without "
+        "this flag, candidates are listed but not moved.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would happen without writing, deleting, or "
+        "moving anything.",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.project_root is None:
+            project_root = find_git_root()
+        else:
+            project_root = args.project_root.expanduser().resolve()
+            if not project_root.is_dir():
+                print(
+                    f"error: --project-root is not a directory: {project_root}",
+                    file=sys.stderr,
+                )
+                return 2
+
+        plan = build_plan(project_root, submodule_ref_target=args.submodule_ref)
+        _print_plan(plan)
+
+        if not plan.has_work:
+            print("nothing to do; project already conforms.")
+            return 0
+
+        result = execute_plan(
+            plan, dry_run=args.dry_run, migrate_all_md=args.migrate_all_md
+        )
+        _print_outcomes(result)
+
+        if not args.dry_run and plan.candidates and not args.migrate_all_md:
+            print()
+            print(
+                "NOTE: non-zero-byte .md candidates were NOT migrated. "
+                "Review the list above and either:"
+            )
+            print("  - rerun with --migrate-all-md to move all of them, or")
+            print(
+                "  - git mv selected files manually and git rm the rest, then"
+            )
+            print("    commit everything together."
+            )
+        return 0
+
+    except NotInsideGitRepositoryError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        print(
+            "hint: cd into a project repository, or pass --project-root.",
+            file=sys.stderr,
+        )
+        return 3
+    except (FileNotFoundError, PermissionError, ValueError, RuntimeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/migrate_to_backup_sessions/migrate_to_backup_sessions.py
+++ b/migrate_to_backup_sessions/migrate_to_backup_sessions.py
@@ -94,6 +94,17 @@ RAW_DIR_REL = BACKUP_DIR_REL / "raw"
 # Kept inline rather than in separate files so the entire tool stays a
 # single Python package with no external asset loading. The text is
 # project-agnostic and does not reference any specific project name.
+#
+# MAINTENANCE NOTE: these templates must stay aligned with the canonical
+# backup/sessions/ convention. If the astfmt pilot's
+# backup/sessions/README.md or the raw/.gitignore content evolves in a
+# way that should propagate to every consumer, update the embedded
+# strings below in the same PR that changes the canonical version,
+# then rerun this tool against each consumer project to refresh the
+# written files. Re-writes are idempotent for the directory + dotfiles,
+# but README content is written only when missing — to force a refresh
+# in an already-migrated project, delete the target file first and
+# rerun.
 
 
 BACKUP_SESSIONS_README = """\
@@ -502,15 +513,31 @@ def _print_plan(plan: MigrationPlan) -> None:
         )
         for o in plan.orphan_tracked_exports:
             print(f"  - {o.source.relative_to(plan.project_root)} ({o.size_bytes} bytes)")
+        print()
+        print("  *** HUMAN JUDGMENT REQUIRED — ORPHANS ARE INTENTIONALLY UNTOUCHED ***")
+        print()
         print(
             "  These files have real content but are NOT .md artifacts the"
         )
         print(
-            "  convention preserves (typically old Claude_Code_Export .txt"
+            "  backup/sessions/ convention preserves (typically old"
         )
         print(
-            "  transcripts). The tool will NOT touch them automatically."
+            "  Claude_Code_Export .txt transcripts from before the /export"
         )
+        print(
+            "  regression). The tool will NOT touch them — this is a"
+        )
+        print(
+            "  deliberate safety property, not an oversight. Their fate"
+        )
+        print(
+            "  depends on their conversation value, which only a human"
+        )
+        print(
+            "  operator can judge."
+        )
+        print()
         print(
             "  Adding exports/ to .gitignore does NOT untrack them; they"
         )

--- a/migrate_to_backup_sessions/models.py
+++ b/migrate_to_backup_sessions/models.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# models.py - Data models for migrate_to_backup_sessions
+# ==============================================================================
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+# See LICENSE file in the project root.
+# ==============================================================================
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional
+
+
+class TaskKind(Enum):
+    """The discrete operations this tool can perform.
+
+    Each one is idempotent: running it against a project where the
+    target state is already satisfied does nothing and reports
+    ``already_done=True``.
+    """
+    CREATE_BACKUP_SESSIONS_DIR = "create_backup_sessions_dir"
+    CREATE_BACKUP_SESSIONS_README = "create_backup_sessions_readme"
+    CREATE_RAW_GITIGNORE = "create_raw_gitignore"
+    ADD_EXPORTS_TO_GITIGNORE = "add_exports_to_gitignore"
+    REMOVE_ZERO_BYTE_EXPORT = "remove_zero_byte_export"
+    BUMP_SUBMODULE_POINTER = "bump_submodule_pointer"
+    MIGRATE_MEANINGFUL_MD = "migrate_meaningful_md"
+
+
+@dataclass(frozen=True)
+class Task:
+    """A single unit of work the tool can apply.
+
+    ``target`` is the path (or submodule path) being operated on.
+    ``detail`` is a short human-readable description used in both
+    the planning report and the execution report.
+    """
+    kind: TaskKind
+    target: Path
+    detail: str
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A non-zero-byte .md file in exports/ that may need migrating.
+
+    The default mode lists candidates for human review rather than
+    moving them, because judgment is required: some legacy exports
+    are meaningful alignment notes or PR review packages worth
+    preserving, others are stale scratch that should just be
+    dropped. The ``--migrate-all-md`` mode converts every candidate
+    into a MIGRATE_MEANINGFUL_MD task automatically.
+    """
+    source: Path             # absolute path to the file in exports/
+    size_bytes: int
+    commit_sha: Optional[str]         # first commit that added this file
+    commit_timestamp_utc: Optional[str]  # YYYYMMDDTHHMMSSZ, or None if unknown
+    target_name: str         # <timestamp>__<basename> planned destination name
+
+
+@dataclass(frozen=True)
+class OrphanTrackedExport:
+    """A tracked, non-zero-byte, non-.md file in exports/.
+
+    These are a distinct category from migration Candidates. They
+    have real content but are not markdown artifacts the convention
+    preserves — typically old Claude_Code_Export .txt transcripts
+    from before the CLI regression. The tool does NOT touch them
+    automatically: it surfaces them so the operator can decide
+    whether to git rm (drop from HEAD, still in history) or
+    manually git mv into backup/sessions/ for conversation-value
+    preservation. Once exports/ is added to .gitignore, leaving
+    them tracked means they stay in the index forever; the
+    operator must untrack them explicitly.
+    """
+    source: Path
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class MigrationPlan:
+    """The full set of work to apply to a project.
+
+    Produced by inspecting the project's current state. Consumers
+    of this dataclass should always check ``candidates`` AND
+    ``orphan_tracked_exports`` in addition to ``tasks`` because
+    those two lists are human-judgment items that are NOT part of
+    the automatic execution unless the caller opts in via
+    ``--migrate-all-md`` (which only applies to candidates, not
+    orphans).
+    """
+    project_root: Path
+    submodule_ref_target: str
+    tasks: List[Task] = field(default_factory=list)
+    candidates: List[Candidate] = field(default_factory=list)
+    orphan_tracked_exports: List[OrphanTrackedExport] = field(default_factory=list)
+    already_done: List[str] = field(default_factory=list)
+
+    @property
+    def has_work(self) -> bool:
+        return (
+            bool(self.tasks)
+            or bool(self.candidates)
+            or bool(self.orphan_tracked_exports)
+        )
+
+
+@dataclass(frozen=True)
+class TaskOutcome:
+    """The result of executing one Task."""
+    task: Task
+    applied: bool            # False if it was already done or dry-run
+    message: str
+
+
+@dataclass(frozen=True)
+class MigrationResult:
+    """The cumulative result of executing a plan."""
+    plan: MigrationPlan
+    outcomes: List[TaskOutcome]
+    dry_run: bool
+
+    @property
+    def applied_count(self) -> int:
+        return sum(1 for o in self.outcomes if o.applied)
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(1 for o in self.outcomes if not o.applied)


### PR DESCRIPTION
## Summary

New shared tool for **idempotently rolling out the backup/sessions/ convention** across the 11 consumer projects (adafmt, astengine, astfmt, tzif_ada, zoneinfo_ada, hybrid_lib_ada, hybrid_app_ada, hybrid_lib_go, hybrid_app_go, hybrid_lib_cpp, clara, functional). Paired with \`session_snapshot\` and \`jsonl_snapshot\`.

astfmt was already migrated manually as the pilot (PR #58 on that repo). This tool exists so the remaining 10 projects can be brought to the same state mechanically, without per-project hand-editing.

## What it does per project

1. Create \`backup/sessions/\` if missing
2. Write \`backup/sessions/README.md\` from an embedded project-agnostic template
3. Write \`backup/sessions/raw/.gitignore\` so the raw subdir is tracked but its contents are ignored
4. Add \`exports/\` to root \`.gitignore\` with an explanatory comment
5. \`git rm\` any tracked 0-byte files under \`exports/\` (broken \`/export\` stubs)
6. Bump \`scripts/python/shared\` submodule pointer (default: current hybrid_scripts_python main HEAD)
7. Surface non-zero-byte \`.md\` files as **migration candidates** for human review; optionally auto-migrate via \`--migrate-all-md\`
8. Surface non-zero-byte non-\`.md\` tracked files as **\`[WARNING]\` orphans** — NOT auto-migrated, operator decides \`git rm\` vs manual \`git mv\`

## Safety properties

- **Idempotent**: rerunning on a conforming project is a no-op ("nothing to do")
- **Never commits**: all changes staged, operator reviews and commits
- **Never pushes, never opens PRs**: that stays manual per project
- **No \`--force\` behavior**: every write uses "write if missing" semantics; every append checks for a sentinel line; submodule bump is compared against target SHA before running
- **Orphans are read-only by the tool**: big tracked \`.txt\` transcripts (278 KB – 659 KB) are NEVER touched automatically because they represent real conversation content whose fate needs judgment

## Architecture

Full hexagonal layout matching the existing \`session_snapshot\` / \`jsonl_snapshot\` / \`arch_guard\` / \`brand_project\` packages:

\`\`\`
migrate_to_backup_sessions/
├── README.md                               (192 lines — public contract, walkthrough, CLI ref)
├── __init__.py                             (re-exports)
├── __main__.py                             (python -m entry point)
├── migrate_to_backup_sessions.py           (~650 lines — planning + execution + CLI)
├── models.py                               (131 lines — dataclasses, enum of task kinds)
└── adapters/
    ├── filesystem.py                       (mkdir, write-if-missing, list, append-if-missing)
    ├── git_ops.py                          (ls-files, rm, mv, submodule update, first-commit timestamp)
    └── git_root.py                         (duplicated from session_snapshot for self-containment)
\`\`\`

## Smoke tests

All run locally with \`--dry-run\`, no side effects:

| Project | Result |
|---|---|
| **astfmt** (already migrated pilot) | 5 "already done" items, 0 tasks, 0 candidates, 0 orphans — **perfect idempotency** |
| **adafmt** (minimal, no exports tracked) | 4 tasks planned, 0 stubs, 0 candidates, 0 orphans |
| **astengine** (complex, 4 tracked .txt files) | 6 tasks, 0 candidates, **3 orphan \`.txt\` files correctly flagged** with \`[WARNING]\` banner and remediation guidance |
| **hybrid_lib_ada** (just a .gitkeep) | 6 tasks, 0 candidates, 0 orphans |

## CLI reference

\`\`\`
migrate_to_backup_sessions [--project-root DIR]
                           [--submodule-ref SHA]
                           [--migrate-all-md]
                           [--dry-run]
\`\`\`

Defaults:
- \`--project-root\` → \`git rev-parse --show-toplevel\` of CWD
- \`--submodule-ref\` → \`a3ace7031203\` (current hybrid_scripts_python main HEAD)

## Typical operator workflow

\`\`\`bash
cd ~/Ada/github.com/abitofhelp/adafmt

# 1. See the plan
python3 -m migrate_to_backup_sessions --dry-run

# 2. Apply mechanical changes
python3 -m migrate_to_backup_sessions

# 3. If the plan had .md candidates, decide what to do with them
#    and either rerun with --migrate-all-md or handle manually

# 4. If the plan had [WARNING] orphans, handle them manually per
#    the remediation hints in the output

# 5. Review staged changes
git status
git diff --cached

# 6. Commit + push + open PR
\`\`\`

## Test plan

- [x] Smoke-tested against 4 real projects (astfmt, adafmt, astengine, hybrid_lib_ada) — all expected behavior
- [x] Idempotency proved (astfmt rerun is no-op)
- [x] Orphan detection proved (astengine flags 3 .txt files correctly)
- [ ] Optional GPT review of this PR body + tool design
- [ ] Merge
- [ ] Roll out to the 10 remaining consumer projects

## Not in this PR

- Per-project PRs against the 10 consumers — those happen after this merges
- Removing old \`exports/\` content from git history (not in scope; git history is immutable and this tool only affects HEAD)
- A test suite for the tool itself — worth adding in a follow-up PR once we have adoption experience across all 11 consumers