### PR TITLE
feat(makefile): add compile_guides.py for Typst developer guides

### DIFF
--- a/exports/20260420T014520Z__pr4_compile_guides_review_ask.md
+++ b/exports/20260420T014520Z__pr4_compile_guides_review_ask.md
@@ -1,0 +1,69 @@
+# `hybrid_scripts_python` PR #4 — `compile_guides.py` Review Ask
+
+**Date:** 2026-04-20 01:45 UTC
+**PR:** [#4](https://github.com/abitofhelp/hybrid_scripts_python/pull/4)
+**Branch:** `feat-compile-guides`
+**Base:** `main` @ `cf36a0f`
+**Scope:** New sibling script for compiling `docs/guides/*.typ` to PDF. Tooling-only; no existing behavior changed.
+
+---
+
+## Context
+
+Ecosystem convention shift for developer guides: Markdown → Typst. Rationale: Typst handles tables + inline SVG better than Markdown, both key for technical guides. The shared guide template already landed in `shared_docs` (commit `61ba5c1`, `templates/guides/core.typ`).
+
+This PR adds the compile script. The documentation agent (`~/.claude/agents/documentation.md`) was updated in the same session to specify `.typ` for guides with the new template. Consumer projects wire the script in via a new `docs-guides` Makefile target.
+
+## What's in the PR
+
+One new file: `makefile/compile_guides.py` (234 LOC).
+
+Design is a close sibling of `compile_formal_docs.py`:
+
+- Same temp-dir strategy: colocate shared template + project sources, run `typst compile`, write PDFs back to `docs/guides/`.
+- Same `--project-dir` / `--templates-dir` / `--dry-run` flag shape.
+- Targets `docs/guides/` and `~/shared_docs/templates/guides/` instead of `docs/formal/` and `~/shared_docs/templates/formal/`.
+
+## Why sibling, not parameterize
+
+Considered generalizing `compile_formal_docs.py` with a `--subdir` and `--templates-dir` flag pair. Rejected because:
+
+- The formal script is already on 11 projects via the submodule, tested, working in CI. Generalizing carries breakage risk for formal-doc builds.
+- The two doc classes have subtly different lifecycles: formal docs have a profile block and version/status lifecycle; guides don't. Keeping entry points separate makes the diff between "formal doc build" and "guide build" visible at the script level.
+- If we later want to DRY shared logic, we can extract a common module without disrupting either entry point.
+
+## Consumer wiring
+
+Downstream projects add:
+
+```makefile
+docs-guides: ## Compile Typst developer guides to PDF
+	@python3 scripts/python/shared/makefile/compile_guides.py
+```
+
+astfmt has already added this (plus an aggregate `docs` target that runs formal + guides). Waiting on this PR to merge + submodule pointer bump to land in the astfmt PR #92 branch.
+
+## Verification
+
+- Smoke-tested locally against astfmt's new `docs/guides/logger_setup.typ`:
+  - `python3 compile_guides.py --project-dir /path/to/astfmt` → 1 succeeded, 0 failed; rendered a 122 KB PDF.
+- `--dry-run` flag lists what would be compiled without running `typst`.
+- Missing `typst` binary → clear error.
+- Missing `docs/guides/` directory → clear error.
+- Missing `--templates-dir` → clear error.
+
+## Specific review asks
+
+1. **Sibling vs generalization** — is the sibling-script call right for long-term ecosystem maintenance, or would you rather see a shared helper module that both `compile_formal_docs.py` and `compile_guides.py` import?
+2. **Default templates dir** — hard-coded to `~/shared_docs/templates/guides`. Same pattern as the formal sibling. Acceptable?
+3. **PDF output location** — written back to `docs/guides/` (alongside the `.typ` source), not a separate `build/` or `_out/` directory. Same as the formal sibling. The `.pdf` is typically committed so CI consumers don't need Typst installed. Confirm that shape?
+4. **Any policy knob you'd add** — e.g., `--fail-on-warnings`? The script currently passes Typst's exit code through but doesn't escalate warnings.
+
+## Out of scope
+
+- Migration of existing `docs/guides/*.md` files in sibling projects (e.g., `hybrid_lib_ada` has four). Separate per-project exercise.
+- A `compile_docs.py` umbrella script that invokes both siblings. Trivial to add later; left out to keep this PR focused.
+
+---
+
+If approved, I merge PR #4 → bump astfmt's submodule pointer on the PR #92 branch → land PR #92 → queue the `hybrid_lib_ada` guide migration for a separate session.

--- a/makefile/compile_guides.py
+++ b/makefile/compile_guides.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# ==============================================================================
+# compile_guides.py
+# ==============================================================================
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+# SPDX-License-Identifier: BSD-3-Clause
+# See LICENSE file in the project root.
+#
+# Purpose:
+#   Compiles Typst developer-guide documents in docs/guides/ to PDF by
+#   colocating project-specific .typ sources with shared guide templates
+#   in a temporary directory, then running the Typst compiler. This is a
+#   sibling of compile_formal_docs.py but targets docs/guides/ and
+#   ~/shared_docs/templates/guides/ instead of docs/formal/ and
+#   ~/shared_docs/templates/formal/.
+#
+# Usage:
+#   From a project root:
+#       python3 scripts/python/shared/makefile/compile_guides.py
+#
+#   From a Makefile:
+#       docs-guides:
+#           @python3 scripts/python/shared/makefile/compile_guides.py
+#
+#   With explicit paths:
+#       python3 compile_guides.py \
+#           --project-dir /path/to/project \
+#           --templates-dir /path/to/shared_docs/templates/guides
+#
+# Design Notes:
+#   Mirrors compile_formal_docs.py design (same temp-dir strategy) to
+#   avoid symlinks or extra gitmodules. The core.typ shared with all
+#   guide sources is copied into the temp build directory alongside
+#   project .typ sources. Output PDFs land in docs/guides/ next to
+#   their sources.
+#
+#   Keeping this as a sibling (rather than parameterizing
+#   compile_formal_docs.py) preserves a dedicated entry point for
+#   each document class, so a breakage in one path cannot silently
+#   take down the other. Shared logic can be refactored later if
+#   churn justifies it.
+#
+# See Also:
+#   compile_formal_docs.py — formal-doc sibling.
+#   ~/shared_docs/templates/guides/ — shared Typst guide templates.
+#   docs/guides/ — project-specific guide sources and rendered PDFs.
+# ==============================================================================
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Default path to shared Typst templates for guides.
+DEFAULT_TEMPLATES_DIR = Path.home() / "shared_docs" / "templates" / "guides"
+
+# Shared template files to copy into the build directory.
+SHARED_TEMPLATES = ["core.typ"]
+
+# Project guide doc sources are any .typ files in docs/guides/ that are
+# not shared templates.
+GUIDES_SUBDIR = Path("docs") / "guides"
+
+
+def find_project_root(start: Path) -> Path | None:
+    """
+    Walk upward from start to find the project root (contains docs/guides/).
+
+    Args:
+        start: Directory to start searching from.
+
+    Returns:
+        The project root path, or None if not found.
+    """
+    current = start.resolve()
+    for _ in range(10):
+        if (current / GUIDES_SUBDIR).is_dir():
+            return current
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+    return None
+
+
+def compile_guides(
+    project_dir: Path,
+    templates_dir: Path,
+    dry_run: bool = False,
+) -> int:
+    """
+    Compile all Typst guide documents in a project to PDF.
+
+    Args:
+        project_dir: Project root directory.
+        templates_dir: Directory containing shared Typst guide templates.
+        dry_run: If True, show what would be done without compiling.
+
+    Returns:
+        0 on success, 1 on failure.
+    """
+    guides_dir = project_dir / GUIDES_SUBDIR
+
+    if not guides_dir.is_dir():
+        print(f"ERROR: The guides directory does not exist: {guides_dir}",
+              file=sys.stderr)
+        return 1
+
+    if not templates_dir.is_dir():
+        print(f"ERROR: The templates directory does not exist: {templates_dir}",
+              file=sys.stderr)
+        return 1
+
+    # Find project .typ sources (exclude shared templates by name).
+    shared_names = set(SHARED_TEMPLATES)
+    project_sources = sorted(
+        p for p in guides_dir.glob("*.typ")
+        if p.name not in shared_names
+    )
+
+    if not project_sources:
+        print("No .typ guide documents were found to compile.")
+        return 0
+
+    print(f"Project: {project_dir.name}")
+    print(f"Templates: {templates_dir}")
+    print(f"Documents: {len(project_sources)}")
+    for src in project_sources:
+        print(f"  - {src.name}")
+    print()
+
+    if dry_run:
+        for src in project_sources:
+            pdf_name = src.with_suffix(".pdf").name
+            print(f"  [dry-run] Would compile {src.name} -> {guides_dir / pdf_name}")
+        return 0
+
+    # Create temporary build directory, compile, clean up.
+    with tempfile.TemporaryDirectory(prefix="typst_guides_build_") as tmp:
+        tmp_dir = Path(tmp)
+
+        # Copy shared templates into the build directory.
+        for template_name in SHARED_TEMPLATES:
+            src_path = templates_dir / template_name
+            if src_path.is_file():
+                shutil.copy2(src_path, tmp_dir / template_name)
+
+        # Copy project .typ sources into the build directory.
+        for src in project_sources:
+            shutil.copy2(src, tmp_dir / src.name)
+
+        # Compile each document.
+        succeeded = 0
+        failed = 0
+
+        for src in project_sources:
+            typ_path = tmp_dir / src.name
+            pdf_name = src.with_suffix(".pdf").name
+            pdf_path = guides_dir / pdf_name
+
+            result = subprocess.run(
+                ["typst", "compile", str(typ_path), str(pdf_path)],
+                capture_output=True,
+                text=True,
+            )
+
+            if result.returncode == 0:
+                print(f"  OK: {src.name} -> {pdf_name}")
+                succeeded += 1
+            else:
+                print(f"  FAILED: {src.name}", file=sys.stderr)
+                if result.stderr:
+                    print(result.stderr.rstrip(), file=sys.stderr)
+                failed += 1
+
+        print(f"\nDone. {succeeded} succeeded, {failed} failed.")
+        return 1 if failed > 0 else 0
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parse command-line arguments.
+
+    Returns:
+        Parsed argument namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description="Compile Typst developer-guide documents to PDF.",
+    )
+    parser.add_argument(
+        "--project-dir",
+        type=Path,
+        default=None,
+        help="Project root directory (auto-detected if omitted).",
+    )
+    parser.add_argument(
+        "--templates-dir",
+        type=Path,
+        default=DEFAULT_TEMPLATES_DIR,
+        help=f"Shared Typst templates directory (default: {DEFAULT_TEMPLATES_DIR}).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without compiling.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Main entry point."""
+    args = parse_args()
+
+    if args.project_dir is not None:
+        project_dir = args.project_dir.resolve()
+    else:
+        project_dir = find_project_root(Path.cwd())
+        if project_dir is None:
+            print("ERROR: Could not find a project root with docs/guides/. "
+                  "Run from a project directory or use --project-dir.",
+                  file=sys.stderr)
+            return 1
+
+    if not shutil.which("typst"):
+        print("ERROR: The typst compiler was not found in PATH.", file=sys.stderr)
+        return 1
+
+    return compile_guides(project_dir, args.templates_dir, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a sibling to `compile_formal_docs.py` that compiles `docs/guides/*.typ` into PDFs using the shared guide template at `~/shared_docs/templates/guides/`.

## Motivation

Consumer projects are switching the developer-guide convention from Markdown to Typst so guides benefit from Typst's better tables + inline SVG diagram support. The shared guide template already landed in \`shared_docs\` (commit 61ba5c1).

## Design

- Sibling of \`compile_formal_docs.py\` (not a generalization of it). Keeping separate entry points means a breakage in one doc class cannot silently take down the other.
- Same temp-dir compile strategy: copy shared templates + project sources to a temp directory, run \`typst compile\`, write PDFs back to \`docs/guides/\`.
- \`--project-dir\` / \`--templates-dir\` / \`--dry-run\` flags match the formal sibling.

## Consumer wiring

Downstream projects add a new \`docs-guides\` Make target:

\`\`\`makefile
docs-guides: ## Compile Typst developer guides to PDF
	@python3 scripts/python/shared/makefile/compile_guides.py
\`\`\`

## Out of scope

Migrating existing \`docs/guides/*.md\` files in sibling projects (e.g., hybrid_lib_ada has four) is a separate per-project exercise. This PR only adds the tooling.