### PR TITLE
fix(coverage): gnatcov 26 compatibility — Step 1..5 dual-path support

### DIFF
--- a/backup/sessions/20260425T030000Z__coverage_ada_gnatcov26_pr_review_ask.md
+++ b/backup/sessions/20260425T030000Z__coverage_ada_gnatcov26_pr_review_ask.md
@@ -1,0 +1,132 @@
+# PR Review Ask — `coverage_ada.py` GNATcov 26 compatibility (issue #5)
+
+**Branch**: `fix-coverage-ada-gnatcov26`
+**Base**: `main` @ `da1e5be`
+**Closes**: hybrid_scripts_python#5
+**Kind**: Tooling fix in shared submodule. **Strawman-validated end-to-end.** No consumer rollout in this PR (per GPT direction lock).
+
+## Why
+
+Discovered during astfmt §8 cutover-readiness audit: `coverage_ada.py` Step 1 silently produced an incomplete install on gnatcov 26.x (`obj/` only, no `share/gpr/gnatcov_rts.gpr`), causing Step 2 (`gnatcov instrument`) to fail with "Could not load the coverage runtime project gnatcov_rts". gnatcov 26 replaced the legacy `gprbuild + gprinstall` setup sequence with a single `gnatcov setup --prefix=<path>` command. The script wasn't updated.
+
+Astfmt closed §8 with the §8.b coverage gate WAIVED under D-062, with the waiver retiring once this issue lands and a downstream `make coverage` produces a usable report.
+
+## What changed
+
+### 1. New helper: `gnatcov_major_version(cwd)`
+
+Parses `alr exec -- gnatcov --version` output (stdout or stderr) for the leading `MAJOR.minor[.patch]` token. Returns `None` on parse failure or subprocess error so callers can fall back to the legacy path.
+
+### 2. Refactored `build_gnatcov_runtime(cfg, force=False)`
+
+Dispatches by major version:
+- **v26+**: `alr exec -- gnatcov setup --prefix=<cfg.gnatcov_rts_prefix>` (single command; `gnatcov setup` finds the runtime sources itself)
+- **v22 (legacy fallback)**: existing `gprbuild + gprinstall` against the runtime source
+
+Both paths now validate against the same post-install property — `<prefix>/share/gpr/gnatcov_rts.gpr` exists — so the rest of `coverage_ada.py` doesn't need to know which path produced the install. New `_gnatcov_rts_gpr_installed(prefix)` helper centralises the check (also used by the idempotent "already built" short-circuit at the top of `build_gnatcov_runtime`).
+
+### 3. Step 3 implicit-with selector
+
+GNATcov v22 ships `gnatcov_rts.gpr` and `gnatcov_rts_full.gpr`; v26 ships only `gnatcov_rts.gpr`. New `_gnatcov_rts_implicit_with(prefix)` helper picks `_full.gpr` when present (preserving v22 behaviour) and falls back to the plain GPR (v26). Both `gprbuild` invocations in `build_instrumented_tests` now use this helper.
+
+### 4. `GPR_PROJECT_PATH` correction (latent bug)
+
+The two `instrument_tests` / `build_instrumented_tests` env settings used `GPR_PROJECT_PATH=<prefix>:...`. The runtime project is installed at `<prefix>/share/gpr/`, not at `<prefix>` directly. Both sites now point at `<prefix>/share/gpr`. This was wrong on v22 too; v22 may have been masking it via PATH search heuristics, but the fix is universal. (Not a v26-only issue, but exposed by the v26 strawman.)
+
+### 5. HTML→xcov annotated-report fallback (Step 5)
+
+The gnatcov 26 **binary** distribution does not ship Dynamic HTML report support ("HTML report format support is not installed"). The script now tries `--annotate=html` first; if it fails with that specific error, falls back to `--annotate=xcov` (always available, plain-text per-file annotation). Source-built gnatcov retains HTML; binary builds get a usable report via xcov. New `_generate_annotated_report` helper. Success message updated to reflect the chosen format.
+
+## Strawman E2E (per GPT direction)
+
+A minimal Ada strawman with one branched function and a runner that exercises all three branches was built in `/tmp/strawman/` inside `dev-container-ada-system-1`. End-to-end on gnatcov 26.2.1, ARM64 Linux:
+
+```
+=== Step 1: build_gnatcov_runtime ===
+✓ GNATcov runtime installed (v26 path) at /tmp/strawman/external/gnatcov_rts/install
+=== Step 2: instrument_tests (unit only) ===
+✓ Instrumentation complete
+=== Step 3: build_instrumented_tests ===
+✓ Build complete
+=== Step 4: run_tests ===
+✓ Generated 1 trace file(s)
+=== Step 5: generate_reports ===
+  ⚠ Dynamic HTML support not installed in this gnatcov build; falling back to xcov.
+  Format: xcov
+✓ Coverage Analysis Complete!
+=== ALL STEPS GREEN ===
+```
+
+The text summary report shows STMT and DECISION coverage with "No violation" — the strawman's three branches were all exercised, end-to-end with real instrumented binaries.
+
+## Round-trip proof
+
+| Step | Pre-patch (gnatcov 26) | Post-patch (gnatcov 26) |
+|------|------------------------|-------------------------|
+| Step 1: runtime install | claims success, but `share/gpr/gnatcov_rts.gpr` missing | `share/gpr/gnatcov_rts.gpr` present ✓ |
+| Step 2: instrument | "Could not load the coverage runtime project" | ✓ |
+| Step 3: build | (not reached) | `--implicit-with=gnatcov_rts.gpr` ✓ |
+| Step 4: run | (not reached) | trace file produced ✓ |
+| Step 5: report | (not reached) | HTML→xcov fallback emits annotated report ✓ |
+
+## Tests
+
+15 new pytest cases in `tests/test_coverage_ada_gnatcov_version.py`:
+- `gnatcov_major_version` parses typical version-string shapes (v22, v26, source-built `XCOV FSF 26.2`, stderr-only output, unparseable output)
+- Returns `None` on subprocess errors / timeouts
+- Parses successfully even when subprocess returns non-zero (`check=False`) so flaky `alr` doesn't lose v26 dispatch
+- `_gnatcov_rts_implicit_with` prefers `_full.gpr` when present (v22) and falls back to plain (v26)
+- `_gnatcov_rts_gpr_installed` is True iff `<prefix>/share/gpr/gnatcov_rts.gpr` exists; explicitly False when only `obj/` is present (the original bug)
+
+```
+$ python3 -m pytest tests/
+============================== 36 passed in 0.07s ==============================
+```
+
+(15 new + 21 existing = 36 total.)
+
+## Out of scope (next PRs)
+
+Per GPT direction lock — this PR is the strawman-validated tooling fix. **Consumer rollout is separate work**:
+
+1. **Identify actual `coverage_ada.py` users** (not all 12 submodule consumers — Go/C++ repos may import but not use).
+2. For each Ada consumer that uses it: bump `test/alire.toml` from `gnatcov = "^22.0.1"` to `gnatcov = "^26"`, bump the `scripts/python/shared` submodule pointer to this PR's merged commit, run `make test-coverage` to confirm.
+3. astfmt is the obvious first integration target (D-062 retirement gate). hybrid_lib_ada / hybrid_app_ada / functional / clara / adafmt / tzif_ada / zoneinfo_ada follow as needed.
+4. astfmt §8.b re-enters and D-062 retires once astfmt's `make coverage` produces a successful GNATcov run + an evaluable report.
+
+## Review asks for GPT
+
+1. **Version-detection mechanism** — `alr exec -- gnatcov --version` parsed from stdout+stderr. Sufficient, or do you want a more robust mechanism (e.g., parse `alr show gnatcov --solve`)? The current approach has the property that an environment without `alr` at all (manually-installed gnatcov on PATH) returns `None` and falls back to legacy — by design.
+
+2. **HTML→xcov fallback** — discovered empirically that the gnatcov 26 **binary** distribution does not ship Dynamic HTML support; only source builds do. Right tradeoff to fall back silently to xcov (with a `⚠` note), or should the script bail and require source-built gnatcov for HTML? Defaulting to xcov keeps coverage usable everywhere; bailing forces awareness but blocks consumers.
+
+3. **`GPR_PROJECT_PATH` correction (latent v22 bug)** — bundling this fix into the v26 PR is correct, or should I split it into a separate "fix env path" PR for clarity? My read: it's a one-character diff in two places and the strawman wouldn't have worked without it, so keeping it bundled is more honest.
+
+4. **`_gnatcov_rts_implicit_with` selector** — picks `_full.gpr` when present (v22 behavior) else `gnatcov_rts.gpr` (v26). Right behavior, or should v26 also try `_full` first as a forward-compat hedge? My read: v26 binary packs everything into the plain GPR; using `_full` on v26 would fail.
+
+5. **Idempotent short-circuit** at the top of `build_gnatcov_runtime` — uses `_gnatcov_rts_gpr_installed(prefix)` (the same check both v22 and v26 paths satisfy). Tighter than the previous `(prefix / "share" / "gpr").exists()` check (which was true on the v26 bug state — the directory exists with manifests/ but no .gpr). Right call?
+
+6. **Strawman test plan coverage** — runtime setup (Step 1), instrumentation (Step 2), instrumented-build (Step 3), execution (Step 4), report generation (Step 5 via xcov fallback). Per your direction lock — was this thorough enough, or do you want me to add a v22 strawman too? The current Alire index makes v22 unresolvable, so a v22 strawman would require a manual gnatcov 22 install outside Alire.
+
+7. **Anything missed** — the patch is small but cross-cutting (Steps 1, 2, 3, 5 all touched). PR is deliberately tooling-only; consumer rollout is post-merge.
+
+## Scope discipline (NOT done)
+
+- **No** consumer rollout (separate PRs)
+- **No** Ada source change anywhere
+- **No** `test/alire.toml` constraint bumps in any consumer
+- **No** submodule pointer bumps anywhere
+- **No** astfmt-side change (D-062 retirement is a follow-on PR after this lands)
+
+## My merge disposition leaning
+
+**Approve.** The strawman E2E is the strongest signal — every step that was previously broken on v26 is now green, with the HTML/xcov fallback handling the binary-distribution constraint cleanly. 36/36 pytest tests passing (15 new). Strawman + unit tests + round-trip proof gives high confidence for the consumer rollout.
+
+## References
+
+- Pre-phase ask: `astfmt/backup/sessions/20260424T000000Z__gnatcov_ecosystem_issue.md`
+- GPT direction lock: `astfmt/backup/sessions/20260424T001500Z__gnatcov_ecosystem_issue_gpt_lock.md`
+- astfmt D-062 (the §8.b waiver this unblocks): `astfmt/docs/disposition.csv`
+- Issue: hybrid_scripts_python#5
+
+Closes #5

--- a/makefile/coverage_ada.py
+++ b/makefile/coverage_ada.py
@@ -163,6 +163,38 @@ def run_alr(args: list[str], cwd: Path | None = None, env: dict | None = None,
 # Step 1: Build GNATcov Runtime
 # =============================================================================
 
+def gnatcov_major_version(cwd: Path) -> int | None:
+    """Return the major version of `gnatcov` resolved by Alire in ``cwd``.
+
+    GNATcov ≥ 26 replaced the legacy ``gprbuild + gprinstall`` runtime-setup
+    sequence with a single ``gnatcov setup --prefix=<path>`` command. This
+    helper parses the version so the runtime-build step can dispatch to the
+    correct path. Returns ``None`` if the version cannot be determined
+    (callers should treat that as "fall back to legacy path").
+    """
+    import re
+
+    try:
+        proc = subprocess.run(
+            ["alr", "exec", "--", "gnatcov", "--version"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+    output = (proc.stdout or "") + (proc.stderr or "")
+    # Typical output: "GNATcoverage 26.2.1 (xxxxx) ..." — match leading
+    # major.minor.patch on the first non-empty line that mentions a version.
+    match = re.search(r"\b(\d+)\.\d+(?:\.\d+)?\b", output)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
 def find_gnatcov_rts_source(root: Path) -> Path | None:
     """Find the gnatcov_rts source in Alire dependencies or global releases."""
     # Search in local cache directories
@@ -191,18 +223,67 @@ def find_gnatcov_rts_source(root: Path) -> Path | None:
     return None
 
 
-def build_gnatcov_runtime(cfg: Config, force: bool = False) -> bool:
-    """Build and install the GNATcov runtime library."""
-    print("\n" + "=" * 70)
-    print("Step 1: GNATcov Runtime")
-    print("=" * 70)
+def _gnatcov_rts_implicit_with(prefix: Path) -> str:
+    """Return the runtime GPR name suitable for ``--implicit-with``.
 
-    # Check if already built
-    if not force and (cfg.gnatcov_rts_prefix / "share" / "gpr").exists():
-        print(f"✓ Runtime already installed at {cfg.gnatcov_rts_prefix}")
-        return True
+    GNATcov v22 ships both ``gnatcov_rts.gpr`` and ``gnatcov_rts_full.gpr``;
+    consumers historically used ``_full`` because it bundles richer trace I/O.
+    GNATcov v26 ships only ``gnatcov_rts.gpr``. This helper picks ``_full``
+    when present (preserving v22 behavior) and falls back to the plain GPR
+    otherwise (v26).
+    """
+    if (prefix / "share" / "gpr" / "gnatcov_rts_full.gpr").is_file():
+        return "gnatcov_rts_full.gpr"
+    return "gnatcov_rts.gpr"
 
-    # Find source
+
+def _gnatcov_rts_gpr_installed(prefix: Path) -> bool:
+    """Return True iff the post-install layout contains share/gpr/gnatcov_rts.gpr.
+
+    The legacy v22 path produced share/gpr/ with the project file inside; the
+    v26 ``gnatcov setup`` command produces the same layout. Both paths are
+    validated against this property, so a successful Step 1 always leaves the
+    runtime project loadable via ``GPR_PROJECT_PATH=<prefix>/share/gpr``.
+    """
+    return (prefix / "share" / "gpr" / "gnatcov_rts.gpr").is_file()
+
+
+def _build_gnatcov_runtime_v26(cfg: Config) -> bool:
+    """v26+ path: single ``gnatcov setup --prefix=<path>`` invocation.
+
+    GNATcov 26 replaced the legacy ``gprbuild + gprinstall`` runtime-setup
+    sequence with this single command. ``gnatcov setup`` finds the runtime
+    sources itself (they ship inside the gnatcov binary release), so the
+    explicit ``find_gnatcov_rts_source`` step is not used on this path.
+    """
+    print(f"  v26 path: gnatcov setup --prefix={cfg.gnatcov_rts_prefix}")
+    try:
+        run_alr(
+            ["gnatcov", "setup", f"--prefix={cfg.gnatcov_rts_prefix}"],
+            cwd=cfg.test_dir,
+        )
+    except subprocess.CalledProcessError:
+        print("✗ gnatcov setup failed")
+        return False
+
+    if not _gnatcov_rts_gpr_installed(cfg.gnatcov_rts_prefix):
+        print(
+            f"✗ gnatcov setup completed but "
+            f"{cfg.gnatcov_rts_prefix}/share/gpr/gnatcov_rts.gpr is missing"
+        )
+        return False
+
+    print(f"✓ GNATcov runtime installed (v26 path) at {cfg.gnatcov_rts_prefix}")
+    return True
+
+
+def _build_gnatcov_runtime_legacy(cfg: Config) -> bool:
+    """v22 fallback path: gprbuild + gprinstall against gnatcov_rts source.
+
+    Kept for older toolchains and offline environments where ``gnatcov 22``
+    is the only resolvable version. Identical to the original
+    ``build_gnatcov_runtime`` body.
+    """
     rts_source = find_gnatcov_rts_source(cfg.root)
     if rts_source is None:
         print("✗ Cannot find gnatcov_rts in Alire dependencies.")
@@ -210,12 +291,9 @@ def build_gnatcov_runtime(cfg: Config, force: bool = False) -> bool:
         print("  Then run: cd test && alr update")
         return False
 
+    print(f"  v22 legacy path:")
     print(f"  Building from: {rts_source}")
     print(f"  Installing to: {cfg.gnatcov_rts_prefix}")
-
-    # Clean if forcing rebuild
-    if force and cfg.gnatcov_rts_prefix.exists():
-        shutil.rmtree(cfg.gnatcov_rts_prefix)
 
     cfg.gnatcov_rts_prefix.mkdir(parents=True, exist_ok=True)
 
@@ -227,7 +305,6 @@ def build_gnatcov_runtime(cfg: Config, force: bool = False) -> bool:
         print(f"✗ Cannot find gnatcov_rts GPR file in {rts_source}")
         return False
 
-    # Build
     try:
         run_cmd([
             "gprbuild", "-P", str(gpr_file), "-p", "-j0",
@@ -237,7 +314,6 @@ def build_gnatcov_runtime(cfg: Config, force: bool = False) -> bool:
         print("✗ gprbuild failed")
         return False
 
-    # Install
     try:
         run_cmd([
             "gprinstall", "-P", str(gpr_file), "-p",
@@ -249,8 +325,51 @@ def build_gnatcov_runtime(cfg: Config, force: bool = False) -> bool:
         print("✗ gprinstall failed")
         return False
 
-    print("✓ GNATcov runtime installed")
+    if not _gnatcov_rts_gpr_installed(cfg.gnatcov_rts_prefix):
+        print(
+            f"✗ gprinstall completed but "
+            f"{cfg.gnatcov_rts_prefix}/share/gpr/gnatcov_rts.gpr is missing"
+        )
+        return False
+
+    print(f"✓ GNATcov runtime installed (v22 legacy path) at {cfg.gnatcov_rts_prefix}")
     return True
+
+
+def build_gnatcov_runtime(cfg: Config, force: bool = False) -> bool:
+    """Build and install the GNATcov runtime library.
+
+    Dispatches by gnatcov major version:
+
+    * v26+ — ``gnatcov setup --prefix=<cfg.gnatcov_rts_prefix>``
+    * v22  — legacy ``gprbuild + gprinstall`` against the runtime source
+
+    Both paths are validated against the same post-install property
+    (``<prefix>/share/gpr/gnatcov_rts.gpr`` exists) so the rest of
+    ``coverage_ada.py`` does not need to know which path produced the
+    install.
+    """
+    print("\n" + "=" * 70)
+    print("Step 1: GNATcov Runtime")
+    print("=" * 70)
+
+    # Idempotency: already built
+    if not force and _gnatcov_rts_gpr_installed(cfg.gnatcov_rts_prefix):
+        print(f"✓ Runtime already installed at {cfg.gnatcov_rts_prefix}")
+        return True
+
+    # Clean if forcing rebuild
+    if force and cfg.gnatcov_rts_prefix.exists():
+        shutil.rmtree(cfg.gnatcov_rts_prefix)
+
+    major = gnatcov_major_version(cfg.test_dir)
+    if major is None:
+        print("⚠ Could not determine gnatcov major version; using legacy path.")
+        return _build_gnatcov_runtime_legacy(cfg)
+
+    if major >= 26:
+        return _build_gnatcov_runtime_v26(cfg)
+    return _build_gnatcov_runtime_legacy(cfg)
 
 
 # =============================================================================
@@ -267,7 +386,7 @@ def instrument_tests(cfg: Config, run_unit: bool, run_integration: bool) -> bool
     for instr_dir in cfg.root.glob("**/gnatcov-instr"):
         shutil.rmtree(instr_dir, ignore_errors=True)
 
-    env = {"GPR_PROJECT_PATH": f"{cfg.gnatcov_rts_prefix}:{os.environ.get('GPR_PROJECT_PATH', '')}"}
+    env = {"GPR_PROJECT_PATH": f"{cfg.gnatcov_rts_prefix}/share/gpr:{os.environ.get('GPR_PROJECT_PATH', '')}"}
 
     # Use --no-subprojects to avoid parsing transitive dependencies
     # gnatcov may not support newer Ada features like 'Reduce in external deps
@@ -336,7 +455,8 @@ def build_instrumented_tests(cfg: Config, run_unit: bool, run_integration: bool)
     print("Step 3: Build Instrumented Tests")
     print("=" * 70)
 
-    env = {"GPR_PROJECT_PATH": f"{cfg.gnatcov_rts_prefix}:{os.environ.get('GPR_PROJECT_PATH', '')}"}
+    env = {"GPR_PROJECT_PATH": f"{cfg.gnatcov_rts_prefix}/share/gpr:{os.environ.get('GPR_PROJECT_PATH', '')}"}
+    implicit_with = _gnatcov_rts_implicit_with(cfg.gnatcov_rts_prefix)
 
     if run_unit and cfg.unit_tests_gpr.exists():
         print("\n  Building unit tests...")
@@ -345,7 +465,7 @@ def build_instrumented_tests(cfg: Config, run_unit: bool, run_integration: bool)
                 "gprbuild", "-f", "-p", "-j0",
                 "-P", str(cfg.unit_tests_gpr),
                 "--src-subdirs=gnatcov-instr",
-                "--implicit-with=gnatcov_rts_full.gpr",
+                f"--implicit-with={implicit_with}",
             ], cwd=cfg.test_dir, env=env)
         except subprocess.CalledProcessError:
             print("✗ Unit test build failed")
@@ -358,7 +478,7 @@ def build_instrumented_tests(cfg: Config, run_unit: bool, run_integration: bool)
                 "gprbuild", "-f", "-p", "-j0",
                 "-P", str(cfg.integration_tests_gpr),
                 "--src-subdirs=gnatcov-instr",
-                "--implicit-with=gnatcov_rts_full.gpr",
+                f"--implicit-with={implicit_with}",
             ], cwd=cfg.test_dir, env=env)
         except subprocess.CalledProcessError:
             print("✗ Integration test build failed")
@@ -434,6 +554,46 @@ def should_exclude(filepath: Path, patterns: list[str]) -> bool:
     return False
 
 
+def _generate_annotated_report(
+    cfg: Config, sid_list: Path, trace_list: Path
+) -> tuple[str | None, Path | None]:
+    """Generate the annotated report; prefer HTML, fall back to xcov.
+
+    Returns ``(format, index_path)`` on success or ``(None, None)`` if both
+    formats fail. On HTML success ``index_path`` points at ``index.html``;
+    on xcov fallback there is no index file so ``index_path`` is the report
+    directory itself.
+    """
+    for fmt in ("html", "xcov"):
+        result = run_alr(
+            [
+                "gnatcov", "coverage",
+                "--level=stmt+decision",
+                "--sid", f"@{sid_list}",
+                f"--annotate={fmt}",
+                "--output-dir", str(cfg.report_dir),
+                f"@{trace_list}",
+            ],
+            cwd=cfg.test_dir,
+            check=False,
+            capture=True,
+        )
+        combined = (result.stdout or "") + (result.stderr or "")
+        if result.returncode == 0:
+            index = cfg.report_dir / ("index.html" if fmt == "html" else "stats")
+            return fmt, index if index.exists() else cfg.report_dir
+        if "HTML report format support is not installed" in combined:
+            print(
+                "  ⚠ Dynamic HTML support not installed in this gnatcov "
+                "build; falling back to xcov."
+            )
+            continue
+        # Other failure mode: dump the captured output and stop trying.
+        sys.stderr.write(combined)
+        return None, None
+    return None, None
+
+
 def generate_reports(cfg: Config) -> bool:
     """Generate coverage reports from trace files."""
     print("\n" + "=" * 70)
@@ -472,20 +632,19 @@ def generate_reports(cfg: Config) -> bool:
             f.write(f"{trace}\n")
     print(f"  Found {len(trace_files)} trace file(s)")
 
-    # Generate HTML report
-    print("\n  Generating HTML report...")
-    try:
-        run_alr([
-            "gnatcov", "coverage",
-            "--level=stmt+decision",
-            "--sid", f"@{sid_list}",
-            "--annotate=html",
-            "--output-dir", str(cfg.report_dir),
-            f"@{trace_list}",
-        ], cwd=cfg.test_dir)
-    except subprocess.CalledProcessError:
-        print("✗ HTML report generation failed")
+    # Generate annotated report. Prefer HTML; fall back to xcov when the
+    # gnatcov binary distribution lacks HTML support (gnatcov 26.x binary
+    # builds do not ship Dynamic HTML — only source-built gnatcov includes
+    # it). The xcov format is plain-text per-file annotation and is always
+    # available; reports remain machine- and human-readable either way.
+    print("\n  Generating annotated report...")
+    annotate_format, report_index = _generate_annotated_report(
+        cfg, sid_list, trace_list,
+    )
+    if annotate_format is None:
+        print("✗ Annotated report generation failed")
         return False
+    print(f"  Format: {annotate_format}")
 
     # Generate text summary
     summary_file = cfg.coverage_dir / "summary.txt"
@@ -506,7 +665,9 @@ def generate_reports(cfg: Config) -> bool:
     print("\n" + "=" * 70)
     print("✓ Coverage Analysis Complete!")
     print("=" * 70)
-    print(f"\n  HTML Report: {cfg.report_dir / 'index.html'}")
+    if report_index is not None:
+        label = "HTML Report" if annotate_format == "html" else "Annotated Report"
+        print(f"\n  {label}: {report_index}")
     print(f"  Summary:     {summary_file}")
 
     # Print summary excerpt

--- a/makefile/coverage_ada.py
+++ b/makefile/coverage_ada.py
@@ -584,8 +584,8 @@ def _generate_annotated_report(
             return fmt, index if index.exists() else cfg.report_dir
         if "HTML report format support is not installed" in combined:
             print(
-                "  ⚠ Dynamic HTML support not installed in this gnatcov "
-                "build; falling back to xcov."
+                f"  ⚠ Dynamic HTML support not installed in this gnatcov "
+                f"build; falling back to xcov (output at {cfg.report_dir})."
             )
             continue
         # Other failure mode: dump the captured output and stop trying.

--- a/tests/test_coverage_ada_gnatcov_version.py
+++ b/tests/test_coverage_ada_gnatcov_version.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+"""Tests for the gnatcov version-detection helpers in
+``makefile.coverage_ada`` (PR for issue #5 — gnatcov 26 compatibility).
+
+Coverage:
+- ``gnatcov_major_version`` parses typical version-string shapes:
+  * ``GNATcoverage 26.2.1 (sha)`` → 26
+  * ``XCOV FSF 26.2`` (older format from --version) → 26
+  * ``GNATcoverage 22.0.1`` → 22
+  * stderr-only output (some toolchains emit version on stderr) → parsed
+  * unparseable output → ``None`` (caller falls back to legacy path)
+  * ``alr exec`` non-zero exit → ``None``
+- ``_gnatcov_rts_implicit_with`` picks ``gnatcov_rts_full.gpr`` when the
+  v22 layout is present and ``gnatcov_rts.gpr`` otherwise (v26).
+- ``_gnatcov_rts_gpr_installed`` returns True iff
+  ``<prefix>/share/gpr/gnatcov_rts.gpr`` is present (validates both v22
+  and v26 install layouts against the same property).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "makefile"))
+
+import coverage_ada  # type: ignore  # noqa: E402
+
+
+def _make_completed_proc(returncode: int, stdout: str = "", stderr: str = ""):
+    """Build a fake ``subprocess.CompletedProcess`` for monkeypatching."""
+    return types.SimpleNamespace(
+        returncode=returncode, stdout=stdout, stderr=stderr,
+    )
+
+
+@pytest.mark.parametrize(
+    "stdout,stderr,expected",
+    [
+        ("GNATcoverage 26.2.1 (b465e28d)\n", "", 26),
+        ("", "GNATcoverage 26.2.1 (b465e28d)\n", 26),
+        ("XCOV FSF 26.2\n", "", 26),
+        ("GNATcoverage 22.0.1\n", "", 22),
+        ("GNATcoverage 1.0\n", "", 1),
+        ("no version anywhere here\n", "", None),
+        ("", "", None),
+    ],
+)
+def test_gnatcov_major_version_parses_typical_outputs(
+    stdout: str, stderr: str, expected: int | None, tmp_path: Path
+) -> None:
+    with patch.object(coverage_ada.subprocess, "run") as mock_run:
+        mock_run.return_value = _make_completed_proc(0, stdout, stderr)
+        got = coverage_ada.gnatcov_major_version(tmp_path)
+    assert got == expected
+
+
+def test_gnatcov_major_version_returns_none_on_subprocess_error(
+    tmp_path: Path,
+) -> None:
+    with patch.object(coverage_ada.subprocess, "run") as mock_run:
+        mock_run.side_effect = FileNotFoundError("alr not on PATH")
+        got = coverage_ada.gnatcov_major_version(tmp_path)
+    assert got is None
+
+
+def test_gnatcov_major_version_returns_none_on_timeout(
+    tmp_path: Path,
+) -> None:
+    with patch.object(coverage_ada.subprocess, "run") as mock_run:
+        mock_run.side_effect = coverage_ada.subprocess.TimeoutExpired(
+            cmd=["alr"], timeout=60,
+        )
+        got = coverage_ada.gnatcov_major_version(tmp_path)
+    assert got is None
+
+
+def test_gnatcov_major_version_parses_when_subprocess_returns_nonzero(
+    tmp_path: Path,
+) -> None:
+    """Even non-zero exits can carry a parseable version string. The helper
+    uses ``check=False`` and parses whatever output it sees, so callers
+    don't lose v26 dispatch on a flaky alr invocation."""
+    with patch.object(coverage_ada.subprocess, "run") as mock_run:
+        mock_run.return_value = _make_completed_proc(
+            returncode=1, stdout="GNATcoverage 26.2.1\n", stderr="warn:...\n",
+        )
+        got = coverage_ada.gnatcov_major_version(tmp_path)
+    assert got == 26
+
+
+def test_gnatcov_rts_implicit_with_prefers_full_when_present(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "share" / "gpr").mkdir(parents=True)
+    (tmp_path / "share" / "gpr" / "gnatcov_rts_full.gpr").write_text(
+        "project Gnatcov_Rts_Full is end Gnatcov_Rts_Full;\n",
+    )
+    assert (
+        coverage_ada._gnatcov_rts_implicit_with(tmp_path)
+        == "gnatcov_rts_full.gpr"
+    )
+
+
+def test_gnatcov_rts_implicit_with_falls_back_to_plain(tmp_path: Path) -> None:
+    # Empty prefix or v26 layout: only gnatcov_rts.gpr (or none).
+    assert (
+        coverage_ada._gnatcov_rts_implicit_with(tmp_path) == "gnatcov_rts.gpr"
+    )
+
+
+def test_gnatcov_rts_gpr_installed_true_when_file_present(
+    tmp_path: Path,
+) -> None:
+    gpr = tmp_path / "share" / "gpr" / "gnatcov_rts.gpr"
+    gpr.parent.mkdir(parents=True)
+    gpr.write_text("project Gnatcov_Rts is end Gnatcov_Rts;\n")
+    assert coverage_ada._gnatcov_rts_gpr_installed(tmp_path) is True
+
+
+def test_gnatcov_rts_gpr_installed_false_when_only_obj_present(
+    tmp_path: Path,
+) -> None:
+    """Reproduces the original v26 bug: gprinstall on a v26 binary
+    deposits only ``obj/`` at the prefix (no ``share/gpr/``). The helper
+    must NOT return True for that incomplete state."""
+    (tmp_path / "obj").mkdir()
+    assert coverage_ada._gnatcov_rts_gpr_installed(tmp_path) is False
+
+
+def test_gnatcov_rts_gpr_installed_false_on_empty_prefix(
+    tmp_path: Path,
+) -> None:
+    assert coverage_ada._gnatcov_rts_gpr_installed(tmp_path) is False


### PR DESCRIPTION
## Summary

Closes #5. Strawman-validated end-to-end on gnatcov 26.2.1, ARM64 Linux. **No consumer rollout in this PR** (per GPT direction lock — separate follow-on PRs).

`coverage_ada.py` now dispatches by gnatcov major version:
- **v26+** — single `gnatcov setup --prefix=<path>` (replaces broken `gprbuild + gprinstall` sequence)
- **v22 fallback** — existing legacy path retained for older toolchains

Plus four supporting fixes the strawman exposed:
- Latent `GPR_PROJECT_PATH` bug (was `<prefix>` instead of `<prefix>/share/gpr`)
- Step 3 `--implicit-with=` now picks `gnatcov_rts_full.gpr` when present (v22) and falls back to `gnatcov_rts.gpr` (v26 ships only the latter)
- Step 5 HTML report falls back to xcov when gnatcov binary distribution lacks Dynamic HTML support
- Idempotent short-circuit now uses the same `_gnatcov_rts_gpr_installed()` helper that both paths satisfy

## Strawman E2E (per GPT direction)

```
=== Step 1: build_gnatcov_runtime ===  ✓ v26 path
=== Step 2: instrument_tests ===       ✓
=== Step 3: build_instrumented_tests ===  ✓
=== Step 4: run_tests ===              ✓ trace produced
=== Step 5: generate_reports ===       ✓ html→xcov fallback (binary distribution)
=== ALL STEPS GREEN ===
```

Annotated report output shows STMT and DECISION coverage with "No violation" — the strawman's three branches all exercised.

## Tests

- 15 new pytest cases in `tests/test_coverage_ada_gnatcov_version.py`
- Full suite: **36/36** passing (15 new + 21 existing)

## Round-trip proof

| Step | Pre-patch (gnatcov 26) | Post-patch |
|---|---|---|
| 1 | claims success, `share/gpr/gnatcov_rts.gpr` missing | present ✓ |
| 2 | "Could not load coverage runtime project" | ✓ |
| 3 | (not reached) | implicit-with picks correct GPR ✓ |
| 4 | (not reached) | trace produced ✓ |
| 5 | (not reached) | xcov fallback report ✓ |

## Review ask

Forensic trail: `backup/sessions/20260425T030000Z__coverage_ada_gnatcov26_pr_review_ask.md`

## Out of scope (follow-ons)

- Consumer rollout (per-repo `test/alire.toml` bumps + submodule pointer bumps)
- astfmt D-062 (§8.b coverage waiver) retirement — gated on a downstream `make coverage` run producing a usable report

## References

- Pre-phase + GPT direction lock: archived in astfmt's `backup/sessions/` (2026-04-24)
- astfmt D-062 (the waiver this unblocks)

Closes #5