### PR TITLE
feat(coverage): GPRBUILD_EXTRA_ARGS env-var plumbing

### DIFF
--- a/backup/sessions/20260425T040000Z__gprbuild_extra_args_pr_review_ask.md
+++ b/backup/sessions/20260425T040000Z__gprbuild_extra_args_pr_review_ask.md
@@ -1,0 +1,71 @@
+# PR Review Ask — `coverage_ada.py` `GPRBUILD_EXTRA_ARGS` plumbing
+
+**Branch**: `add-gprbuild-extra-args`
+**Base**: `main` @ `b55ad6d`
+**Kind**: Small follow-up to PR #7. Generic per-consumer scenario-flag plumbing for the shared coverage script.
+**Triggered by**: astfmt's D-062 retirement attempt — Step 3 instrumented `gprbuild` failed with `cannot find -liconv` because astfmt's normal build uses `-XGNATCOLL_ICONV_OPT=` (glibc-Linux iconv-disable scenario var) and the shared script wasn't propagating any equivalent.
+
+## What changed
+
+- New `gprbuild_extra_args()` helper reads `GPRBUILD_EXTRA_ARGS` from the environment and shell-tokenises it via `shlex.split(...)`.
+- Applied at the **two `gprbuild` invocation sites** that consumers' build flags affect:
+  - Step 1 legacy `gprbuild` (v22 fallback runtime build)
+  - Step 3 instrumented test `gprbuild` (both unit and integration)
+- **NOT applied** to `gnatcov setup` (v26+; not gprbuild), `gnatcov instrument`, or `gnatcov coverage`.
+
+Per owner direction:
+
+> astfmt's iconv flag is per-project build policy. It belongs in astfmt's Makefile target, not the shared script. The shared script should expose a generic mechanism and stay project-agnostic.
+
+## Why a separate PR
+
+Issue #5 was closed by PR #7 (gnatcov 26 setup compatibility). The iconv linker error surfaced when applying that PR to the real astfmt consumer. Bundling this fix into a hypothetical "PR #7 amendment" would have muddied the v26/v22 dispatch story; splitting it into a targeted "extra-args plumbing" PR keeps each cycle's diff focused and reviewable in isolation. The astfmt-side D-062 retirement (which depends on this PR) is the third PR in the chain.
+
+## Tests
+
+5 new pytest cases in `tests/test_coverage_ada_extra_args.py`:
+- Returns `[]` when env var unset.
+- Returns `[]` on blank/whitespace-only value (regression pin: `shlex.split('')` returning `[]`).
+- Single flag (`-XGNATCOLL_ICONV_OPT=`) round-trips intact.
+- Multiple space-separated flags split correctly.
+- Quoted values with embedded spaces stay a single token.
+
+Full pytest suite: **41/41** passing (5 new + 36 prior).
+
+## Consumer wiring (astfmt-side, applied in the next PR)
+
+```make
+test-coverage:
+	@GPRBUILD_EXTRA_ARGS="-XGNATCOLL_ICONV_OPT=" \
+	  $(PYTHON3) scripts/python/shared/makefile/coverage_ada.py
+```
+
+That single line is what the chain needs astfmt-side. Other consumers may pass their own scenario flags (e.g. `-XLIBRARY_TYPE=static` or `-XBUILD_PROFILE=...`) the same way.
+
+## Review asks for GPT
+
+1. **Application sites** — applied at legacy Step 1 `gprbuild` + Step 3 `gprbuild` (unit + integration), per the owner's directive: "Apply it to legacy Step 1 gprbuild + Step 3 instrumented test gprbuild. Do NOT apply it to gnatcov setup or gnatcov instrument." Coverage matches your direction?
+
+2. **`shlex.split` for tokenisation** — single-flag and quoted-multi-flag values round-trip correctly. Right tool, or do you prefer a more conservative `str.split()` (which would reject quoted-string semantics)?
+
+3. **Helper visibility** — `gprbuild_extra_args()` is a module-level public function; the docstring explicitly enumerates the application sites and the not-applied list, so future contributors don't accidentally extend coverage to `gnatcov instrument`. Right place to lock that contract, or do you prefer a more rigid mechanism (e.g. an explicit allowlist of phases)?
+
+4. **Test coverage** — five cases covering unset / blank / single / multi-flag / quoted-value. Sufficient, or do you want a negative-path test (e.g. unbalanced quotes raising `ValueError` from `shlex.split`)?
+
+5. **Anything missed** before merge? Patch is deliberately minimal; the value lives in being a tiny, separate PR rather than getting bundled.
+
+## Scope discipline (NOT done)
+
+- **No** Ada source change anywhere
+- **No** consumer rollout (astfmt-side wiring is the next PR)
+- **No** Step 2 / Step 4 / Step 5 change
+- **No** `gnatcov instrument` / `gnatcov coverage` / `gnatcov setup` change
+
+## My merge disposition leaning
+
+**Approve.** The patch is deliberately small (one helper + two `+ extra_args` insertions) and the test suite provides the contract that future regressions need to clear. PR #7's strawman E2E remains valid since `GPRBUILD_EXTRA_ARGS` defaults to empty.
+
+## References
+
+- Issue #5 + PR #7 (gnatcov 26 compatibility — the parent)
+- astfmt D-062 (the §8.b waiver retirement that this PR unblocks)

--- a/makefile/coverage_ada.py
+++ b/makefile/coverage_ada.py
@@ -32,10 +32,33 @@ Project-Local Exclusions:
 
 import argparse
 import os
+import shlex
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+
+def gprbuild_extra_args() -> list[str]:
+    """Return any extra `gprbuild` flags from the ``GPRBUILD_EXTRA_ARGS``
+    environment variable.
+
+    Consumers whose build requires per-project scenario flags (e.g.
+    ``-XGNATCOLL_ICONV_OPT=`` to disable iconv linking on glibc Linux)
+    can set this env var in their Makefile target without modifying the
+    shared script. The value is shell-tokenised via :func:`shlex.split`,
+    so multi-flag invocations like
+    ``GPRBUILD_EXTRA_ARGS="-XFOO=bar -XBAZ=qux"`` work as expected.
+
+    Applied to:
+        * Step 1 legacy ``gprbuild`` runtime path (kept for v22 fallback)
+        * Step 3 instrumented test ``gprbuild``
+    Not applied to:
+        * ``gnatcov setup`` (v26+; not a gprbuild invocation)
+        * ``gnatcov instrument``
+        * ``gnatcov coverage``
+    """
+    return shlex.split(os.environ.get("GPRBUILD_EXTRA_ARGS", ""))
 
 
 # =============================================================================
@@ -309,7 +332,7 @@ def _build_gnatcov_runtime_legacy(cfg: Config) -> bool:
         run_cmd([
             "gprbuild", "-P", str(gpr_file), "-p", "-j0",
             f"--relocate-build-tree={cfg.gnatcov_rts_prefix}/obj",
-        ], cwd=rts_source)
+        ] + gprbuild_extra_args(), cwd=rts_source)
     except subprocess.CalledProcessError:
         print("✗ gprbuild failed")
         return False
@@ -458,6 +481,8 @@ def build_instrumented_tests(cfg: Config, run_unit: bool, run_integration: bool)
     env = {"GPR_PROJECT_PATH": f"{cfg.gnatcov_rts_prefix}/share/gpr:{os.environ.get('GPR_PROJECT_PATH', '')}"}
     implicit_with = _gnatcov_rts_implicit_with(cfg.gnatcov_rts_prefix)
 
+    extra_args = gprbuild_extra_args()
+
     if run_unit and cfg.unit_tests_gpr.exists():
         print("\n  Building unit tests...")
         try:
@@ -466,7 +491,7 @@ def build_instrumented_tests(cfg: Config, run_unit: bool, run_integration: bool)
                 "-P", str(cfg.unit_tests_gpr),
                 "--src-subdirs=gnatcov-instr",
                 f"--implicit-with={implicit_with}",
-            ], cwd=cfg.test_dir, env=env)
+            ] + extra_args, cwd=cfg.test_dir, env=env)
         except subprocess.CalledProcessError:
             print("✗ Unit test build failed")
             return False
@@ -479,7 +504,7 @@ def build_instrumented_tests(cfg: Config, run_unit: bool, run_integration: bool)
                 "-P", str(cfg.integration_tests_gpr),
                 "--src-subdirs=gnatcov-instr",
                 f"--implicit-with={implicit_with}",
-            ], cwd=cfg.test_dir, env=env)
+            ] + extra_args, cwd=cfg.test_dir, env=env)
         except subprocess.CalledProcessError:
             print("✗ Integration test build failed")
             return False

--- a/tests/test_coverage_ada_extra_args.py
+++ b/tests/test_coverage_ada_extra_args.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+"""Tests for ``gprbuild_extra_args`` in ``makefile.coverage_ada``.
+
+The helper exposes per-consumer scenario flags (e.g. astfmt's
+``-XGNATCOLL_ICONV_OPT=`` for glibc-Linux iconv-disable) without
+embedding project-specific knowledge in the shared script. Consumers
+set ``GPRBUILD_EXTRA_ARGS`` in their Makefile target; the script
+appends the shell-tokenised value to its ``gprbuild`` invocations.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "makefile"))
+
+import coverage_ada  # type: ignore  # noqa: E402
+
+
+def test_returns_empty_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GPRBUILD_EXTRA_ARGS", raising=False)
+    assert coverage_ada.gprbuild_extra_args() == []
+
+
+def test_returns_empty_when_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Whitespace-only / empty values must not produce a single empty
+    token. ``shlex.split('')`` already returns ``[]``; this regression
+    test pins that property."""
+    monkeypatch.setenv("GPRBUILD_EXTRA_ARGS", "")
+    assert coverage_ada.gprbuild_extra_args() == []
+    monkeypatch.setenv("GPRBUILD_EXTRA_ARGS", "   ")
+    assert coverage_ada.gprbuild_extra_args() == []
+
+
+def test_single_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GPRBUILD_EXTRA_ARGS", "-XGNATCOLL_ICONV_OPT=")
+    assert coverage_ada.gprbuild_extra_args() == ["-XGNATCOLL_ICONV_OPT="]
+
+
+def test_multiple_flags_split(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "GPRBUILD_EXTRA_ARGS", "-XFOO=bar -XBAZ=qux -XLIBRARY_TYPE=static",
+    )
+    assert coverage_ada.gprbuild_extra_args() == [
+        "-XFOO=bar", "-XBAZ=qux", "-XLIBRARY_TYPE=static",
+    ]
+
+
+def test_quoted_value_with_spaces(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A quoted value with embedded spaces stays a single token."""
+    monkeypatch.setenv(
+        "GPRBUILD_EXTRA_ARGS", '-XSPACED="a b c" -XSIMPLE=42',
+    )
+    assert coverage_ada.gprbuild_extra_args() == [
+        "-XSPACED=a b c", "-XSIMPLE=42",
+    ]


### PR DESCRIPTION
## Summary

Small follow-up to PR #7. Adds a generic per-consumer scenario-flag mechanism so each consumer's Makefile target can pass its own gprbuild flags (e.g. astfmt's `-XGNATCOLL_ICONV_OPT=` for glibc-Linux iconv-disable) without modifying the shared script.

## What changed

- New `gprbuild_extra_args()` helper reads `GPRBUILD_EXTRA_ARGS` from the environment and shell-tokenises it via `shlex.split()`. Returns `[]` when unset or blank.
- Applied at the two `gprbuild` invocation sites consumers' build flags affect:
  - Step 1 legacy `gprbuild` (v22 fallback runtime build)
  - Step 3 instrumented test `gprbuild` (unit + integration)
- **NOT applied** to `gnatcov setup` (v26+; not gprbuild), `gnatcov instrument`, or `gnatcov coverage`.

## Tests

- 5 new pytest cases: unset / blank / single flag / multi-flag / quoted value
- Full pytest suite: **41/41** (5 new + 36 prior)

## Consumer wiring (next PR, astfmt-side)

```make
test-coverage:
	@GPRBUILD_EXTRA_ARGS="-XGNATCOLL_ICONV_OPT=" \
	  $(PYTHON3) scripts/python/shared/makefile/coverage_ada.py
```

## Review ask

Forensic trail: `backup/sessions/20260425T040000Z__gprbuild_extra_args_pr_review_ask.md`

## References

- PR #7 (gnatcov 26 setup compatibility — the parent)
- astfmt D-062 (the §8.b waiver retirement this unblocks)