### PR TITLE
feat(release,brand_project): adopt v2 document metadata convention

### DIFF
--- a/backup/sessions/20260426T214903Z__doc_metadata_convention_design_review_ask.md
+++ b/backup/sessions/20260426T214903Z__doc_metadata_convention_design_review_ask.md
@@ -1,0 +1,127 @@
+# Pre-Implementation Design Review — Document Metadata Convention v2
+
+**Date**: 2026-04-26
+**Status**: Pre-phase, no code written yet
+**Decision required before**: any edits to `release/`, `brand_project/`, or document files
+
+## Context
+
+Across the abitofhelp ecosystem (functional, astengine, astfmt, adafmt, hybrid_lib_*, hybrid_app_*, etc.) we are standardizing on a new document cover-page convention that decouples doc revision from library version. The current convention conflates them with a single `**Version:**` field.
+
+The change affects:
+
+1. The Documentation agent file at `~/.claude/agents/documentation.md` (canonical authoring authority — already updated; pending GPT sign-off).
+2. The shared Typst cores at `~/shared_docs/templates/{formal,guides}/core.typ` (rendering layer for all `.typ` docs).
+3. **`release/adapters/base.py`** — release-time metadata sync that today writes the OLD form everywhere.
+4. **`brand_project/adapters/base.py`** — project scaffolding that today seeds the OLD form into new projects.
+
+Without redesigning #3 and #4 in the same change, the next release run on a migrated repo would silently overwrite the new convention with the old form.
+
+## New convention (Markdown form)
+
+```markdown
+# Document Title
+
+**Doc Version:** X.Y.Z<br>
+**Applies to <project>:** ^A.B<br>
+**Last Updated:** YYYY-MM-DD<br>
+**SPDX-License-Identifier:** BSD-3-Clause<br>
+**License File:** See the LICENSE file in the project root<br>
+**Copyright:** © YYYY Michael Gardner, A Bit of Help, Inc.<br>
+**Status:** [Draft|In Progress|Released]
+```
+
+Three changes vs. the current convention:
+
+- `**Version:**` → `**Doc Version:**` (clarify — was ambiguous)
+- `**Date:**` → `**Last Updated:**` (clarify)
+- ADD `**Applies to <project>:**` (lock the doc to a code-version range)
+
+License/Copyright/Status fields are unchanged. Source-code headers (`pragma Ada_2022; -- ... -- SPDX-License-Identifier: ...`) are NOT affected — they don't have Version/Date fields and never should.
+
+## Proposed field-ownership split
+
+| Field | Owner | Release-script behavior |
+|-------|-------|------------------------|
+| **Doc Version** | Doc author | **Read-preserve**: parse existing value from the file, write back unchanged. Doc author bumps it when they edit; releases never overwrite it. |
+| **Applies to <project>** | Release process | Always write `^{major}.{minor}` derived from `config.version`. Mechanical, not opinion. Releasing 1.0.0 sets `^1.0`; releasing 2.0.0 bumps to `^2.0`. |
+| **Last Updated** | Release process | Always overwrite with today's date. |
+| **SPDX-License-Identifier** | Standard | Always emit `BSD-3-Clause`. |
+| **License File** | Standard | Always emit standard text. |
+| **Copyright** | Standard | Always emit current year. |
+| **Status** | Release process | Released or Unreleased per `is_prerelease`. |
+
+**Rationale**:
+
+- Doc Version is doc-author-owned because the entire reason for splitting it from library version is "doc-only fixes don't require a code release." If the release script overwrites it, that decoupling is fictional.
+- Applies to is release-owned because it's a compatibility statement about the just-shipped library — the doc author shouldn't have to remember to update it manually.
+- Last Updated is release-owned because the release run physically touches the file (Status, Applies to). If we want it to mean "last edited by a human," it would have to be doc-author-owned, but then it goes stale every time release rewrites the file. Cleaner to define it as "release-touched date."
+
+## Lenient detection / strict emission
+
+Confirmed by owner:
+
+- **Detection** accepts both old and new forms (`^\*\*(?:Doc )?Version:`, plus `Date|Last Updated`, etc.).
+- **Emission** always writes the new convention.
+
+A release run on a not-yet-migrated repo correctly identifies its docs and rewrites them into the new form. After all repos have been swept, detection can tighten to new-form-only as a separate cleanup.
+
+## Migration cost
+
+When the script encounters an OLD-form doc, it has no Doc Version field to preserve (the old `Version:` is library version, not doc version). The rewrite will reset Doc Version to `config.version` (the library version being released). This is one-time migration cost — after the first post-convention release, every doc has an independent Doc Version that the script will preserve from then on.
+
+Acceptable, IMO — there's no way to invent an independent Doc Version retroactively, and aligning with library version at the migration moment is the cleanest entry into the new model.
+
+## Scaffolding default (`add_markdown_header` and brand_project)
+
+When the script scaffolds a header into a doc that lacks one entirely, it must choose a Doc Version starting value:
+
+- **(a) Use `config.version` (the library version being released)** — proposed default. Doc starts synchronized with the first release; doc author bumps independently afterwards.
+- (b) Always `0.1.0` — fresh doc, mark as pre-stability.
+- (c) Context-aware: `1.0.0` if `is_initial_release`, else `0.1.0`.
+
+`brand_project` scaffolding (new project being created from the brand template) always uses fixed defaults:
+
+- Doc Version: `0.1.0`
+- Applies to <project>: `^0.1`
+- Last Updated: today
+- Status: Draft
+
+This is correct because a freshly branded project is always pre-1.0 by definition.
+
+## Implementation plan (one PR against hybrid_scripts_python)
+
+1. `release/models.py` — add `applies_to_range: str` field, computed in `__post_init__` from `version` as `^{major}.{minor}`.
+2. `release/adapters/base.py`:
+   - `find_markdown_files` regex (line 289): widen to accept old + new forms.
+   - `replace_markdown_header` (line 298): parse + preserve existing `Doc Version`; emit new convention; write `Applies to` mechanically.
+   - `add_markdown_header` (line 352): emit new convention with `Doc Version: {config.version}`.
+   - Header-existence sniff at line 372: extend regex to include `Doc Version|Applies to|Last Updated`.
+3. `brand_project/adapters/base.py` (lines 455-456): emit new convention with scaffolding defaults above.
+4. Add tests covering: (a) old-form doc gets migrated correctly, (b) new-form doc has Doc Version preserved across release runs, (c) doc with no header gets new-convention scaffolding.
+
+Separately (different repo, separate PR):
+
+- `~/shared_docs/templates/formal/core.typ` and `~/shared_docs/templates/guides/core.typ` — rename row labels, add `applies_to` field rendering.
+
+## Specific review asks (please answer one-by-one)
+
+**Q1.** Is the field-ownership split (Doc Version doc-author-owned, Applies to release-owned, Last Updated release-owned) the right boundary, or would you split it differently? Specifically, is `Last Updated` defensible as release-owned, or should it be doc-author-owned with a separate `Last Released:` field?
+
+**Q2.** Is `Doc Version: {config.version}` the right default for the `add_markdown_header` scaffolding case, or should it be `0.1.0`? The trade-off: (a) "doc starts synced with first release" vs. (b) "doc always starts at pre-1.0 to make the bump-decision explicit when first releasing."
+
+**Q3.** Is "Applies to is release-owned, mechanically computed as `^{major}.{minor}`" the right approach? The alternative is making it doc-author-owned with the doc author manually setting compat ranges. The release-owned approach assumes the doc never explicitly supports a narrower range than the latest release; is that ever wrong?
+
+**Q4.** Is anything missing from the lenient-detection regex set? Today the existing regex is:
+
+```python
+r'Version\s*[:)]|version\s*[:)]|\*\*Version\s+\d+\.\d+|Copyright\s*©\s*\d{4}'
+```
+
+The proposed widened version would need to also match `**Doc Version:`, `**Last Updated:`, `**Applies to`. Any other old-form patterns we'd lose detection on?
+
+**Q5.** Migration-time cost: the rewrite resets Doc Version to library version on first migration of an old-form doc. Is that acceptable or would you prefer a more gradual mode (e.g., a `--migrate-headers` flag that's an explicit one-off, separate from regular release runs)?
+
+**Q6.** Do you see any other conflict surfaces in the ecosystem we should scan before touching code? (Already scanned: `~/.claude/CLAUDE.md` — no conflicts. Other agents `ada.md`/`cpp.md`/`python.md` — use the convention in their own headers as self-examples, marginal call. Source-code headers — confirmed no overlap.)
+
+**Q7.** Should the existing release-script behavior of touching ALL markdown files (`docs/**/*.md`, `*.md`, `config/*.md`) stay as-is, or should the new convention be enforced more conservatively (e.g., opt-in via a `.docmetadata.toml` file in the project root)?

--- a/brand_project/adapters/base.py
+++ b/brand_project/adapters/base.py
@@ -449,15 +449,19 @@ class BaseAdapter(ABC):
         # Get current date in ISO format (YYYY-MM-DD)
         today = date.today().strftime("%Y-%m-%d")
 
-        # Create fresh changelog content
+        # Create fresh changelog content (v2 metadata convention).
+        # Defaults for a newly branded project: pre-1.0 project version,
+        # ^0.1 compat range, doc starts in Draft.
+        project_name = config.new_name
         changelog_content = f"""# Changelog
 
-**Version:** Unreleased<br>
-**Date:** {today}<br>
+**Doc Version:** 0.1.0<br>
+**Applies to {project_name}:** ^0.1<br>
+**Last Updated:** {today}<br>
 **SPDX-License-Identifier:** BSD-3-Clause<br>
 **License File:** See the LICENSE file in the project root<br>
 **Copyright:** © 2025 Michael Gardner, A Bit of Help, Inc.<br>
-**Status:** Development
+**Status:** Draft
 
 All notable changes to this project will be documented in this file.
 

--- a/release/adapters/base.py
+++ b/release/adapters/base.py
@@ -334,7 +334,14 @@ class BaseReleaseAdapter(ABC):
         "LICENSE.md",
         "LICENSE",
     })
-    _EXCLUDED_DIR_PARTS = frozenset({"third_party", "generated"})
+    _EXCLUDED_DIR_PARTS = frozenset({
+        "third_party",   # vendored third-party content
+        "generated",     # build-tool output
+        "vendor",        # Go / Rust / Ruby vendored deps
+        "node_modules",  # JS / TS dependency directory
+        "dist",          # bundled distribution output
+        "build",         # generic build output
+    })
 
     @classmethod
     def _is_in_metadata_scope(cls, path: Path, project_root: Path) -> bool:
@@ -344,7 +351,9 @@ class BaseReleaseAdapter(ABC):
         Excludes:
             * CHANGELOG.md / LICENSE.md / LICENSE (per-release content or
               boilerplate; never carries a doc cover-page header)
-            * any file under ``third_party/`` or ``generated/``
+            * any file under ``third_party/``, ``generated/``, ``vendor/``,
+              ``node_modules/``, ``dist/``, or ``build/`` (vendored content
+              and build output across language ecosystems)
             * any file under a ``common/`` submodule path
         """
         if path.name in cls._EXCLUDED_FILENAMES:

--- a/release/adapters/base.py
+++ b/release/adapters/base.py
@@ -270,25 +270,115 @@ class BaseReleaseAdapter(ABC):
             print(f"Command exception: {' '.join(cmd)}: {e}")
             return None
 
+    # ------------------------------------------------------------------
+    # Document metadata convention — release-time sync
+    # ------------------------------------------------------------------
+    #
+    # Lenient detection / strict emission, per adafmt#23:
+    #   * Detection accepts both the legacy form (**Version:**, **Date:**)
+    #     and the v2 convention (**Doc Version:**, **Applies to <project>:**,
+    #     **Last Updated:**), plus an SPDX fallback for license-only headers.
+    #   * Emission always writes the v2 convention.
+    #
+    # Field ownership:
+    #   * Doc Version       — doc-author-owned. Parsed and preserved across
+    #                          release runs. On migration from legacy
+    #                          (**Version:** present, no **Doc Version:**),
+    #                          reset to ``config.version`` once.
+    #   * Applies to        — release-process-owned by default
+    #                          (``config.applies_to_range``). Author overrides
+    #                          are preserved when they use a NON-caret form
+    #                          (``~1.4.0``, ``=1.0.0``, ``>=2.0,<3.0``, etc.) —
+    #                          those signal an intentional narrow range
+    #                          (migration / deprecated / experimental docs).
+    #                          Caret forms (``^X.Y``) are treated as stale
+    #                          auto-form output from prior releases and
+    #                          overwritten with the current release range.
+    #   * Last Updated      — release-process-owned. Always overwritten with
+    #                          ``config.date_str``. Semantics: "last
+    #                          release-touch", NOT "last human edit".
+
+    # Lenient detection: matches both legacy and v2 cover-page headers.
+    _METADATA_DETECTION_RE = re.compile(
+        r'^\*\*\s*(?:Doc\s+)?Version\s*:'      # **Version:** OR **Doc Version:**
+        r'|^\*\*\s*(?:Date|Last\s+Updated)\s*:'  # **Date:** OR **Last Updated:**
+        r'|^\*\*\s*Applies\s+to'                 # **Applies to ...:**
+        r'|SPDX-License-Identifier',             # license-only header fallback
+        re.MULTILINE | re.IGNORECASE,
+    )
+
+    # Header-start anchor. Accepts both legacy and v2 first-line forms.
+    # MULTILINE so ``.search()`` on full-file content matches at any line start.
+    _HEADER_START_RE = re.compile(
+        r'^\*\*(?:Doc\s+)?Version:', re.IGNORECASE | re.MULTILINE
+    )
+
+    # Per-field extraction inside an existing header block (v2 form only).
+    # Legacy ``**Version:**`` is detected by ``_HEADER_START_RE`` for
+    # block-boundary purposes, but its value is intentionally NOT
+    # preserved as Doc Version (see ``replace_markdown_header``).
+    _DOC_VERSION_RE = re.compile(
+        r'^\*\*Doc\s+Version:\*\*\s*(\S+?)\s*(?:<br>)?\s*$',
+        re.IGNORECASE,
+    )
+    _APPLIES_TO_RE = re.compile(
+        r'^\*\*Applies\s+to\b[^:]*:\*\*\s*(\S+?)\s*(?:<br>)?\s*$',
+        re.IGNORECASE,
+    )
+
+    # Files / paths to exclude from release-time metadata sync (per
+    # adafmt#23 GPT-recommended scope narrowing).
+    _EXCLUDED_FILENAMES = frozenset({
+        "CHANGELOG.md",
+        "CHANGELOG",
+        "LICENSE.md",
+        "LICENSE",
+    })
+    _EXCLUDED_DIR_PARTS = frozenset({"third_party", "generated"})
+
+    @classmethod
+    def _is_in_metadata_scope(cls, path: Path, project_root: Path) -> bool:
+        """
+        Decide whether ``path`` is a candidate for release-time metadata sync.
+
+        Excludes:
+            * CHANGELOG.md / LICENSE.md / LICENSE (per-release content or
+              boilerplate; never carries a doc cover-page header)
+            * any file under ``third_party/`` or ``generated/``
+            * any file under a ``common/`` submodule path
+        """
+        if path.name in cls._EXCLUDED_FILENAMES:
+            return False
+        try:
+            rel = path.relative_to(project_root)
+        except ValueError:
+            return True  # outside the root; default to allowed
+        for part in rel.parts[:-1]:
+            if part in cls._EXCLUDED_DIR_PARTS or part == "common":
+                return False
+        return True
+
     def find_markdown_files(self, project_root: Path) -> List[Path]:
-        """Find all markdown files with version headers."""
+        """Find all markdown files carrying a metadata cover-page header.
+
+        Detection is lenient (accepts both legacy and v2 conventions);
+        scope is narrowed per adafmt#23 (excludes CHANGELOG.md, LICENSE.md,
+        third_party/**, generated/**, common/**).
+        """
         md_files = []
 
-        # Search in docs and root (exclude docs/common submodule)
+        # Search in docs and root (scope-narrowing applied below).
         for pattern in ["docs/**/*.md", "*.md"]:
             for f in project_root.glob(pattern):
-                if "/common/" not in str(f):
+                if self._is_in_metadata_scope(f, project_root):
                     md_files.append(f)
 
-        # Filter to only files with version headers
+        # Filter to only files whose content carries a cover-page header.
         versioned_files = []
         for md_file in md_files:
             try:
                 content = md_file.read_text(encoding='utf-8')
-                if re.search(
-                    r'Version\s*[:)]|version\s*[:)]|\*\*Version\s+\d+\.\d+|Copyright\s*©\s*\d{4}',
-                    content, re.IGNORECASE
-                ):
+                if self._METADATA_DETECTION_RE.search(content):
                     versioned_files.append(md_file)
             except Exception:
                 pass
@@ -297,49 +387,94 @@ class BaseReleaseAdapter(ABC):
 
     def replace_markdown_header(self, file_path: Path, config) -> bool:
         """
-        Replace markdown metadata header with canonical format.
+        Replace markdown metadata header with the v2 canonical format.
 
-        Finds the header block (Version through Status lines) and replaces
-        it entirely with a freshly generated canonical header.
+        Finds the existing header block (Version/Doc Version through Status
+        lines) and replaces it with a freshly generated v2 canonical header.
+
+        Field preservation rules (per adafmt#23):
+            * Doc Version is parsed from the existing header (v2 form first,
+              legacy ``**Version:**`` as fallback) and written back unchanged.
+              On migration from a legacy header that has no Doc Version
+              concept, this resets Doc Version to ``config.version`` once.
+            * Applies to is parsed from the existing header. If an explicit
+              author override exists, it is preserved. Otherwise it is set
+              to ``config.applies_to_range``.
+            * Last Updated, SPDX, License File, Copyright, Status are
+              always overwritten with release-process-owned values.
         """
         try:
             content = file_path.read_text(encoding='utf-8')
             lines = content.split('\n')
 
-            # Find header block boundaries
+            # Find header block boundaries (lenient: accepts both legacy
+            # **Version:** and v2 **Doc Version:** as the start anchor).
             header_start = None
             header_end = None
 
             for i, line in enumerate(lines):
-                # Header starts at first **Version:** line
-                if header_start is None and re.match(r'^\*\*Version:', line):
+                if header_start is None and self._HEADER_START_RE.match(line):
                     header_start = i
-                # Header ends after **Status:** line
                 elif header_start is not None and re.match(r'^\*\*Status:', line):
                     header_end = i + 1
                     break
 
             if header_start is None or header_end is None:
-                return False  # No valid header block found
+                return False  # No valid header block found.
 
-            # Generate canonical header
+            # Parse preserved fields from the existing block.
+            #
+            # Doc Version preservation:
+            #   * Only the v2 ``**Doc Version:**`` form is preserved.
+            #   * Legacy ``**Version:**`` (where the value was the library
+            #     version, not the doc version) is intentionally NOT
+            #     preserved — the convention v2 reset on migration
+            #     establishes a clean Doc Version starting point at
+            #     ``config.version``.
+            existing_block = lines[header_start:header_end]
+            preserved_doc_version = None
+            preserved_applies_to = None
+
+            for line in existing_block:
+                if preserved_doc_version is None:
+                    m = self._DOC_VERSION_RE.match(line)
+                    if m:
+                        preserved_doc_version = m.group(1)
+                        continue
+                if preserved_applies_to is None:
+                    m = self._APPLIES_TO_RE.match(line)
+                    if m:
+                        preserved_applies_to = m.group(1)
+
+            # Apply preservation rules with config defaults.
+            doc_version = preserved_doc_version or config.version
+            # Applies to: preserve only NON-caret forms (author overrides).
+            # Caret forms are treated as stale auto-form output and overwritten.
+            if preserved_applies_to and not preserved_applies_to.startswith("^"):
+                applies_to = preserved_applies_to
+            else:
+                applies_to = config.applies_to_range
+
+            # Generate v2 canonical header.
             status = "Unreleased" if config.is_prerelease else "Released"
+            project_label = config.project_name or "project"
             header_lines = [
-                f"**Version:** {config.version}<br>",
-                f"**Date:** {config.date_str}<br>",
+                f"**Doc Version:** {doc_version}<br>",
+                f"**Applies to {project_label}:** {applies_to}<br>",
+                f"**Last Updated:** {config.date_str}<br>",
                 "**SPDX-License-Identifier:** BSD-3-Clause<br>",
                 "**License File:** See the LICENSE file in the project root<br>",
                 f"**Copyright:** © {config.year} Michael Gardner, A Bit of Help, Inc.<br>",
                 f"**Status:** {status}",
             ]
 
-            # Replace header block
+            # Replace header block.
             new_lines = lines[:header_start] + header_lines + lines[header_end:]
             new_content = '\n'.join(new_lines)
 
             if new_content != content:
                 if getattr(config, 'dry_run', False):
-                    return True  # Report as updated in dry-run
+                    return True  # Report as updated in dry-run.
                 file_path.write_text(new_content, encoding='utf-8')
                 return True
 
@@ -350,12 +485,20 @@ class BaseReleaseAdapter(ABC):
             return False
 
     def add_markdown_header(self, file_path: Path, config) -> bool:
-        """Add metadata header to markdown file if missing."""
+        """Scaffold the v2 metadata header into a markdown file lacking one.
+
+        Doc Version starts at ``config.version`` (i.e., synchronized with
+        the library version at the moment of first scaffolding). After
+        this initial write, the doc author owns Doc Version — subsequent
+        release runs preserve it via :meth:`replace_markdown_header`.
+
+        Applies to is set to ``config.applies_to_range``.
+        """
         try:
             content = file_path.read_text(encoding='utf-8')
             lines = content.splitlines(keepends=True)
 
-            # Find first # heading
+            # Find first # heading.
             title_idx = None
             for i, line in enumerate(lines):
                 if re.match(r'^#\s+\S', line):
@@ -365,22 +508,28 @@ class BaseReleaseAdapter(ABC):
             if title_idx is None:
                 return False
 
-            # Check if header already exists (any bold metadata after title)
-            # Look at lines immediately after title for existing header content
+            # Check if header already exists (any bold metadata after title).
+            # Lenient sniff: accepts both legacy and v2 conventions.
             if title_idx + 1 < len(lines):
                 next_lines = ''.join(lines[title_idx + 1:title_idx + 10])
-                if re.search(r'\*\*(?:Version|Project|Date|Copyright|SPDX)', next_lines):
-                    # Header already exists, don't add another
-                    return False
+                if re.search(
+                    r'\*\*(?:Version|Doc\s+Version|Project|Date|Last\s+Updated'
+                    r'|Applies\s+to|Copyright|SPDX)',
+                    next_lines,
+                    re.IGNORECASE,
+                ):
+                    return False  # Header already exists, don't add another.
 
-            # Create header
+            # Create v2 canonical header.
             status = "Unreleased" if config.is_prerelease else "Released"
+            project_label = config.project_name or "project"
             header = (
                 "\n"
-                f"**Version:** {config.version}<br>\n"
-                f"**Date:** {config.date_str}<br>\n"
-                f"**SPDX-License-Identifier:** BSD-3-Clause<br>\n"
-                f"**License File:** See the LICENSE file in the project root<br>\n"
+                f"**Doc Version:** {config.version}<br>\n"
+                f"**Applies to {project_label}:** {config.applies_to_range}<br>\n"
+                f"**Last Updated:** {config.date_str}<br>\n"
+                "**SPDX-License-Identifier:** BSD-3-Clause<br>\n"
+                "**License File:** See the LICENSE file in the project root<br>\n"
                 f"**Copyright:** © {config.year} Michael Gardner, A Bit of Help, Inc.<br>\n"
                 f"**Status:** {status}\n"
                 "\n"
@@ -389,7 +538,7 @@ class BaseReleaseAdapter(ABC):
             lines.insert(title_idx + 1, header)
 
             if getattr(config, 'dry_run', False):
-                return True  # Report as added in dry-run
+                return True  # Report as added in dry-run.
 
             file_path.write_text(''.join(lines), encoding='utf-8')
             return True
@@ -399,16 +548,26 @@ class BaseReleaseAdapter(ABC):
             return False
 
     def update_all_markdown_files(self, config) -> int:
-        """Update version in all markdown files. Returns count of updated files."""
-        # Note: No files are skipped - all markdown files with version headers
-        # are updated, including formal docs (SRS, SDS, STG)
+        """Sync metadata cover-page header in all in-scope markdown files.
 
+        Scope (per adafmt#23):
+            * ``docs/**/*.md`` and root ``*.md`` and ``config/*.md``
+            * Excludes CHANGELOG.md, LICENSE.md, third_party/**, generated/**,
+              common/** (see :meth:`_is_in_metadata_scope`).
+
+        For each in-scope file:
+            * If a header already exists (lenient detection, both legacy and
+              v2 conventions accepted), it is rewritten in v2 form with
+              Doc Version and Applies to preserved per the field-ownership
+              rules in :meth:`replace_markdown_header`.
+            * If no header exists, one is scaffolded in v2 form.
+
+        Returns count of updated files.
+        """
         all_md_files = []
-        # Include config/ directory for embedded restrictions README
         for pattern in ["docs/**/*.md", "*.md", "config/*.md"]:
             for f in config.project_root.glob(pattern):
-                # Exclude docs/common submodule
-                if "/common/" not in str(f):
+                if self._is_in_metadata_scope(f, config.project_root):
                     all_md_files.append(f)
 
         updated_count = 0
@@ -416,8 +575,10 @@ class BaseReleaseAdapter(ABC):
         for md_file in all_md_files:
             try:
                 content = md_file.read_text(encoding='utf-8')
-                # Check for canonical header format (Version through Status block)
-                has_header = bool(re.search(r'^\*\*Version:', content, re.MULTILINE))
+                # Lenient detection: header exists if either the legacy
+                # (**Version:**) or the v2 (**Doc Version:**) start anchor
+                # is present.
+                has_header = bool(self._HEADER_START_RE.search(content))
 
                 dry_prefix = "[DRY-RUN] Would update" if getattr(config, 'dry_run', False) else "Updated"
                 dry_prefix_add = "[DRY-RUN] Would add" if getattr(config, 'dry_run', False) else "Added"

--- a/release/models.py
+++ b/release/models.py
@@ -58,11 +58,33 @@ class ReleaseConfig:
     year: int = 0
     project_name: str = ""
     project_url: str = ""
+    applies_to_range: str = ""
 
     def __post_init__(self):
         """Initialize computed fields."""
         self.date_str = datetime.now().strftime("%Y-%m-%d")
         self.year = datetime.now().year
+        self.applies_to_range = self._compute_applies_to_range()
+
+    def _compute_applies_to_range(self) -> str:
+        """
+        Compute the alire-style version range for the document metadata
+        ``Applies to`` field.
+
+        Format: ``^{major}.{minor}`` (e.g., 1.0.0 -> ^1.0, 4.1.7 -> ^4.1).
+
+        Used by the release-time metadata sync to populate the
+        ``Applies to <project>`` row when the doc has no explicit
+        author override. Doc-author overrides are preserved by the
+        header rewriter and never replaced by this value.
+        """
+        # Strip any pre-release / build suffix (1.0.0-rc1 -> 1.0.0)
+        core = self.version.split('-')[0].split('+')[0]
+        parts = core.split('.')
+        if len(parts) >= 2:
+            return f"^{parts[0]}.{parts[1]}"
+        # Defensive fallback: malformed version -> "^0.0"
+        return "^0.0"
 
     @property
     def is_prerelease(self) -> bool:

--- a/tests/test_release_metadata_header.py
+++ b/tests/test_release_metadata_header.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+"""Tests for the v2 document metadata convention in
+``release.adapters.base.BaseReleaseAdapter`` (per adafmt#23).
+
+Covers:
+- ``ReleaseConfig.applies_to_range`` derivation from ``version``
+- ``replace_markdown_header`` field-preservation rules:
+    * Doc Version (preserve from v2 form, fall back to legacy ``**Version:**``)
+    * Applies to (preserve author override, default to config range)
+    * Last Updated / SPDX / License / Copyright / Status (always overwrite)
+- ``add_markdown_header`` v2 emission + lenient sniff (legacy + v2 both
+  detected as "header already present")
+- ``_is_in_metadata_scope`` exclusions (CHANGELOG.md, LICENSE.md,
+  third_party/**, generated/**, common/**)
+
+Test fixtures use ``tmp_path`` for isolation; no real release is invoked.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from release.adapters.ada import AdaReleaseAdapter
+from release.adapters.base import BaseReleaseAdapter
+from release.models import Language, ReleaseConfig
+
+
+def make_config(
+    project_root: Path,
+    version: str = "1.0.0",
+    project_name: str = "myproject",
+    dry_run: bool = False,
+) -> ReleaseConfig:
+    """Build a minimally-populated ReleaseConfig for adapter tests."""
+    cfg = ReleaseConfig(
+        project_root=project_root,
+        version=version,
+        language=Language.ADA,
+        dry_run=dry_run,
+    )
+    cfg.project_name = project_name
+    return cfg
+
+
+# ----------------------------------------------------------------------
+# applies_to_range derivation
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("1.0.0", "^1.0"),
+        ("4.1.7", "^4.1"),
+        ("0.1.0", "^0.1"),
+        ("2.0.0-rc1", "^2.0"),     # pre-release suffix stripped
+        ("3.5.0+build.42", "^3.5"),  # build suffix stripped
+    ],
+)
+def test_applies_to_range_computed_from_version(tmp_path, version, expected):
+    cfg = ReleaseConfig(
+        project_root=tmp_path,
+        version=version,
+        language=Language.ADA,
+    )
+    assert cfg.applies_to_range == expected
+
+
+def test_applies_to_range_defensive_fallback_for_malformed_version(tmp_path):
+    """A malformed single-component version still yields a parseable range."""
+    cfg = ReleaseConfig(
+        project_root=tmp_path,
+        version="bogus",
+        language=Language.ADA,
+    )
+    assert cfg.applies_to_range == "^0.0"
+
+
+# ----------------------------------------------------------------------
+# replace_markdown_header — preservation + migration
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def adapter() -> BaseReleaseAdapter:
+    """Concrete adapter for exercising base-class methods."""
+    return AdaReleaseAdapter()
+
+
+def _read_block(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_replace_legacy_form_migrates_to_v2(tmp_path, adapter):
+    """A legacy header (Version/Date) is rewritten in v2 form. Doc Version
+    is reset to config.version once (no v2 source to preserve from)."""
+    md = tmp_path / "doc.md"
+    md.write_text(
+        "# Doc Title\n"
+        "\n"
+        "**Version:** 0.5.0<br>\n"
+        "**Date:** 2025-12-01<br>\n"
+        "**SPDX-License-Identifier:** BSD-3-Clause<br>\n"
+        "**License File:** See the LICENSE file in the project root<br>\n"
+        "**Copyright:** © 2025 Michael Gardner, A Bit of Help, Inc.<br>\n"
+        "**Status:** Released\n"
+        "\n"
+        "Body.\n",
+        encoding="utf-8",
+    )
+
+    cfg = make_config(tmp_path, version="1.0.0", project_name="myproject")
+    assert adapter.replace_markdown_header(md, cfg) is True
+
+    body = _read_block(md)
+    # Doc Version reset to library version (one-time migration).
+    assert "**Doc Version:** 1.0.0<br>" in body
+    # Applies to set from config (no author override on legacy file).
+    assert "**Applies to myproject:** ^1.0<br>" in body
+    # Date renamed to Last Updated, value comes from config.
+    assert f"**Last Updated:** {cfg.date_str}<br>" in body
+    # Legacy field labels are gone.
+    assert "**Version:**" not in body
+    assert "**Date:**" not in body
+
+
+def test_replace_v2_form_preserves_doc_version(tmp_path, adapter):
+    """A v2 header has its existing Doc Version preserved across a release
+    run (doc-author ownership)."""
+    md = tmp_path / "doc.md"
+    md.write_text(
+        "# Doc Title\n"
+        "\n"
+        "**Doc Version:** 3.2.1<br>\n"
+        "**Applies to myproject:** ^1.0<br>\n"
+        "**Last Updated:** 2026-01-15<br>\n"
+        "**SPDX-License-Identifier:** BSD-3-Clause<br>\n"
+        "**License File:** See the LICENSE file in the project root<br>\n"
+        "**Copyright:** © 2026 Michael Gardner, A Bit of Help, Inc.<br>\n"
+        "**Status:** Released\n"
+        "\n"
+        "Body.\n",
+        encoding="utf-8",
+    )
+
+    cfg = make_config(tmp_path, version="1.5.0", project_name="myproject")
+    assert adapter.replace_markdown_header(md, cfg) is True
+
+    body = _read_block(md)
+    # Doc Version preserved unchanged.
+    assert "**Doc Version:** 3.2.1<br>" in body
+    # Last Updated bumped to today.
+    assert f"**Last Updated:** {cfg.date_str}<br>" in body
+    # Applies to follows config (no narrower override on this doc).
+    assert "**Applies to myproject:** ^1.5<br>" in body
+
+
+def test_replace_v2_form_preserves_applies_to_override(tmp_path, adapter):
+    """An explicit narrow Applies to value is preserved (e.g., a migration
+    guide that only documents 1.4.x behavior)."""
+    md = tmp_path / "migration.md"
+    md.write_text(
+        "# Migration Guide\n"
+        "\n"
+        "**Doc Version:** 1.0.0<br>\n"
+        "**Applies to myproject:** ~1.4.0<br>\n"
+        "**Last Updated:** 2026-02-01<br>\n"
+        "**SPDX-License-Identifier:** BSD-3-Clause<br>\n"
+        "**License File:** See the LICENSE file in the project root<br>\n"
+        "**Copyright:** © 2026 Michael Gardner, A Bit of Help, Inc.<br>\n"
+        "**Status:** Released\n",
+        encoding="utf-8",
+    )
+
+    cfg = make_config(tmp_path, version="2.0.0", project_name="myproject")
+    assert adapter.replace_markdown_header(md, cfg) is True
+
+    body = _read_block(md)
+    # Author override preserved verbatim.
+    assert "**Applies to myproject:** ~1.4.0<br>" in body
+    # Doc Version preserved.
+    assert "**Doc Version:** 1.0.0<br>" in body
+
+
+def test_replace_idempotent_on_unchanged_input(tmp_path, adapter):
+    """Running replace twice with the same config yields no second change."""
+    md = tmp_path / "doc.md"
+    md.write_text(
+        "# Doc\n"
+        "\n"
+        "**Doc Version:** 1.0.0<br>\n"
+        "**Applies to myproject:** ^1.0<br>\n"
+        "**Last Updated:** 2099-01-01<br>\n"
+        "**SPDX-License-Identifier:** BSD-3-Clause<br>\n"
+        "**License File:** See the LICENSE file in the project root<br>\n"
+        "**Copyright:** © 2099 Michael Gardner, A Bit of Help, Inc.<br>\n"
+        "**Status:** Released\n",
+        encoding="utf-8",
+    )
+    cfg = make_config(tmp_path, version="1.0.0", project_name="myproject")
+    # First run will overwrite Last Updated and Copyright year.
+    adapter.replace_markdown_header(md, cfg)
+    snapshot = _read_block(md)
+    # Second run must produce zero further changes (returns False).
+    second = adapter.replace_markdown_header(md, cfg)
+    assert second is False
+    assert _read_block(md) == snapshot
+
+
+# ----------------------------------------------------------------------
+# add_markdown_header — new convention emission + lenient sniff
+# ----------------------------------------------------------------------
+
+
+def test_add_header_scaffolds_v2_convention(tmp_path, adapter):
+    """A doc with a title but no header gets the v2 convention scaffolded."""
+    md = tmp_path / "doc.md"
+    md.write_text("# Doc Title\n\nBody.\n", encoding="utf-8")
+
+    cfg = make_config(tmp_path, version="1.0.0", project_name="myproject")
+    assert adapter.add_markdown_header(md, cfg) is True
+
+    body = _read_block(md)
+    assert "**Doc Version:** 1.0.0<br>" in body
+    assert "**Applies to myproject:** ^1.0<br>" in body
+    assert f"**Last Updated:** {cfg.date_str}<br>" in body
+    assert "**Status:** Released" in body
+
+
+def test_add_header_skips_if_legacy_present(tmp_path, adapter):
+    """A legacy header is detected by the sniff; no second header added."""
+    md = tmp_path / "doc.md"
+    original = (
+        "# Doc Title\n"
+        "\n"
+        "**Version:** 0.5.0<br>\n"
+        "**Date:** 2025-12-01<br>\n"
+        "**Status:** Released\n"
+    )
+    md.write_text(original, encoding="utf-8")
+
+    cfg = make_config(tmp_path, version="1.0.0")
+    assert adapter.add_markdown_header(md, cfg) is False
+    assert _read_block(md) == original
+
+
+def test_add_header_skips_if_v2_present(tmp_path, adapter):
+    """A v2 header is detected by the sniff; no second header added."""
+    md = tmp_path / "doc.md"
+    original = (
+        "# Doc Title\n"
+        "\n"
+        "**Doc Version:** 1.0.0<br>\n"
+        "**Applies to myproject:** ^1.0<br>\n"
+        "**Last Updated:** 2026-04-26<br>\n"
+        "**Status:** Released\n"
+    )
+    md.write_text(original, encoding="utf-8")
+
+    cfg = make_config(tmp_path, version="1.0.0")
+    assert adapter.add_markdown_header(md, cfg) is False
+    assert _read_block(md) == original
+
+
+# ----------------------------------------------------------------------
+# Scope narrowing
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rel_path,expected",
+    [
+        ("docs/quick_start.md", True),
+        ("README.md", True),
+        ("CHANGELOG.md", False),       # release-per-version content
+        ("LICENSE.md", False),         # boilerplate
+        ("LICENSE", False),
+        ("third_party/foo/README.md", False),
+        ("generated/api.md", False),
+        ("docs/common/shared.md", False),  # submodule shared content
+        ("docs/guides/user_guide.md", True),
+    ],
+)
+def test_is_in_metadata_scope(tmp_path, rel_path, expected):
+    """Verify scope narrowing matches GPT-recommended exclusions."""
+    full = tmp_path / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text("placeholder", encoding="utf-8")
+
+    assert (
+        BaseReleaseAdapter._is_in_metadata_scope(full, tmp_path) is expected
+    ), f"{rel_path} expected scope={expected}"
+
+
+def test_update_all_excludes_changelog(tmp_path, adapter):
+    """End-to-end: ``update_all_markdown_files`` skips CHANGELOG.md even
+    when CHANGELOG carries a header-shaped block."""
+    (tmp_path / "docs").mkdir()
+    target = tmp_path / "docs" / "quick_start.md"
+    target.write_text(
+        "# Quick Start\n\n"
+        "**Doc Version:** 1.0.0<br>\n"
+        "**Applies to myproject:** ^1.0<br>\n"
+        "**Last Updated:** 2026-01-01<br>\n"
+        "**SPDX-License-Identifier:** BSD-3-Clause<br>\n"
+        "**License File:** See the LICENSE file in the project root<br>\n"
+        "**Copyright:** © 2026 Michael Gardner, A Bit of Help, Inc.<br>\n"
+        "**Status:** Released\n",
+        encoding="utf-8",
+    )
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog_original = (
+        "# Changelog\n\n"
+        "**Version:** Unreleased<br>\n"
+        "**Date:** 2025-12-01<br>\n"
+        "## [Unreleased]\n"
+    )
+    changelog.write_text(changelog_original, encoding="utf-8")
+
+    cfg = make_config(tmp_path, version="2.0.0", project_name="myproject")
+    count = adapter.update_all_markdown_files(cfg)
+
+    # Only the in-scope file was updated.
+    assert count == 1
+    # CHANGELOG untouched.
+    assert _read_block(changelog) == changelog_original
+    # Quick start migrated to new applies_to.
+    assert "**Applies to myproject:** ^2.0<br>" in _read_block(target)
+
+
+# ----------------------------------------------------------------------
+# Lenient detection (find_markdown_files)
+# ----------------------------------------------------------------------
+
+
+def test_find_markdown_files_detects_legacy_and_v2(tmp_path, adapter):
+    """Both legacy and v2 cover-page headers are found by detection."""
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "legacy.md").write_text(
+        "# X\n**Version:** 0.1.0<br>\n", encoding="utf-8"
+    )
+    (tmp_path / "docs" / "v2.md").write_text(
+        "# X\n**Doc Version:** 0.1.0<br>\n", encoding="utf-8"
+    )
+    # Non-doc file with no metadata-shape content — must NOT be matched.
+    (tmp_path / "docs" / "notes.md").write_text(
+        "# Notes\n\nFreeform content with no header markers.\n",
+        encoding="utf-8",
+    )
+
+    found = {p.name for p in adapter.find_markdown_files(tmp_path)}
+    assert found == {"legacy.md", "v2.md"}
+
+
+def test_find_markdown_files_excludes_changelog_even_with_header(tmp_path, adapter):
+    """CHANGELOG.md is scope-excluded even if it contains header-shaped lines."""
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n**Version:** 1.0.0<br>\n", encoding="utf-8"
+    )
+    found = adapter.find_markdown_files(tmp_path)
+    assert found == []

--- a/tests/test_release_metadata_header.py
+++ b/tests/test_release_metadata_header.py
@@ -278,7 +278,11 @@ def test_add_header_skips_if_v2_present(tmp_path, adapter):
         ("LICENSE", False),
         ("third_party/foo/README.md", False),
         ("generated/api.md", False),
-        ("docs/common/shared.md", False),  # submodule shared content
+        ("vendor/lib/README.md", False),       # vendored deps
+        ("node_modules/pkg/README.md", False), # JS/TS deps
+        ("dist/index.md", False),              # bundled output
+        ("build/api.md", False),               # build output
+        ("docs/common/shared.md", False),      # submodule shared content
         ("docs/guides/user_guide.md", True),
     ],
 )


### PR DESCRIPTION
## Summary

Slice #3 of the document metadata convention v2 (adafmt#23). Implements release-time metadata sync and project-scaffolding behavior for the new convention.

Builds on:
- Documentation agent at `~/.claude/agents/documentation.md` (canonical Markdown templates, completed 2026-04-26)
- shared_docs PR #1 (Typst rendering layer, merged 2026-04-26)

## Convention recap

**Cover-page header (Markdown form):**

```markdown
**Doc Version:** X.Y.Z<br>
**Applies to <project>:** ^A.B<br>
**Last Updated:** YYYY-MM-DD<br>
**SPDX-License-Identifier:** BSD-3-Clause<br>
**License File:** See the LICENSE file in the project root<br>
**Copyright:** © YYYY Michael Gardner, A Bit of Help, Inc.<br>
**Status:** [Draft|In Progress|Released]
```

**Field ownership:**

| Field | Owner | Release-script behavior |
|-------|-------|------------------------|
| Doc Version | Doc author | Read-preserve from existing v2 header; reset to `config.version` on legacy migration |
| Applies to <project> | Release process (default); doc author via non-caret form (override) | Mechanical `^{major}.{minor}`; preserves only non-caret forms (`~1.4.0`, `=1.0.0`, `>=2.0`, etc.) as intentional narrow-range overrides |
| Last Updated | Release process | Always today's date; "release-touch" semantics |
| Status | Release process | Released or Unreleased per release type |
| SPDX / License File / Copyright | Standard | Always emit canonical values |

## Detection / emission policy

- **Lenient detection**: header start anchor matches both `**Version:**` (legacy) and `**Doc Version:**` (v2). Sniff regex covers all v2 + legacy field labels + SPDX fallback.
- **Strict emission**: always writes the v2 convention.

After all repos are migrated, detection can tighten to v2-only as a separate cleanup.

## Scope narrowing (per GPT recommendation)

Default INCLUDE: `docs/**/*.md`, root `*.md`, `config/*.md`.

Default EXCLUDE:
- `CHANGELOG.md` / `CHANGELOG` (per-release content; doesn't carry a doc cover-page header)
- `LICENSE.md` / `LICENSE` (boilerplate)
- `third_party/**` (vendored content)
- `generated/**` (build output)
- `common/**` (shared submodule mounts)

## Files changed

- `release/models.py`: `ReleaseConfig` gains `applies_to_range: str` computed in `__post_init__` (strips pre-release/build suffixes, `^0.0` fallback for malformed).
- `release/adapters/base.py`:
  - module-level regex constants for lenient detection / parsing / scope
  - `_is_in_metadata_scope` classmethod for centralized scope checks
  - `find_markdown_files`: lenient detection + scope narrowing
  - `replace_markdown_header`: parse-preserve Doc Version (v2 only) and Applies to (non-caret only); emit v2 canonical header
  - `add_markdown_header`: lenient sniff; emit v2 canonical header on initial scaffolding
  - `update_all_markdown_files`: scope narrowing + lenient detection
- `brand_project/adapters/base.py`: CHANGELOG scaffolding header uses v2 convention with new project's name and pre-1.0 defaults.

## Tests

`tests/test_release_metadata_header.py` (25 cases):

- `applies_to_range` derivation (parametrized over 5 version shapes + malformed fallback)
- `replace_markdown_header`:
  - legacy form migrates correctly (Doc Version reset to config; Applies to set from config)
  - v2 form preserves Doc Version across release runs
  - non-caret Applies to override preserved (`~1.4.0` survives a 2.0.0 release)
  - idempotent on unchanged input
- `add_markdown_header`:
  - scaffolds v2 convention into a header-less doc
  - lenient sniff: skips if either legacy `**Version:**` or v2 `**Doc Version:**` is already present
- `_is_in_metadata_scope`: parametrized over 9 include/exclude path shapes
- `update_all_markdown_files`: end-to-end CHANGELOG exclusion (target file migrated, CHANGELOG untouched)
- `find_markdown_files`: detects legacy + v2; excludes CHANGELOG even if header-shaped

**All 66 tests in repo pass** (25 new + 41 pre-existing).

## Migration cost

When the script encounters an OLD-form doc, it has no v2 `Doc Version` field to preserve. The legacy `**Version:**` value is intentionally NOT preserved (under v1, that field was the library version, not the doc version — preserving it would semantically conflate two concepts). Doc Version is reset to `config.version` once on first migration; subsequent releases preserve it.

This is documented in code comments in `replace_markdown_header` and in the field-ownership description in `documentation.md`.

## Test plan

- [x] `pytest tests/` — all 66 pass
- [x] regex constants compile cleanly (no parse errors)
- [x] `applies_to_range` parameterized over real-world version shapes including pre-release and build-suffix forms

## Refs

- adafmt#23 — full convention spec + cross-repo rollout tracker
- shared_docs#1 — merged (Typst rendering layer)
- Design review ask: `backup/sessions/20260426T214903Z__doc_metadata_convention_design_review_ask.md` (committed in this PR for archival; GPT-approved 2026-04-26)