### PR TITLE
fix(coverage): layered gnatcov_major_version detection — marker regex + Alire-path fallback

### DIFF
--- a/makefile/coverage_ada.py
+++ b/makefile/coverage_ada.py
@@ -210,12 +210,25 @@ def gnatcov_major_version(cwd: Path) -> int | None:
         return None
 
     output = (proc.stdout or "") + (proc.stderr or "")
-    # Typical output: "GNATcoverage 26.2.1 (xxxxx) ..." — match leading
-    # major.minor.patch on the first non-empty line that mentions a version.
-    match = re.search(r"\b(\d+)\.\d+(?:\.\d+)?\b", output)
-    if match is None:
-        return None
-    return int(match.group(1))
+    # Isolate the version match to lines that actually identify gnatcov.
+    # `re.search` over the combined buffer would pick up the FIRST
+    # `digits.digits(.digits)?` it sees, which on hosts where `alr exec`
+    # emits informational banners (e.g. "alr 2.1.0", "GNAT 15.2.1",
+    # "GPRBuild 25.0.1") before the gnatcov line resolves to those
+    # banners — and then the v22 legacy dispatch is taken against v26
+    # runtime sources, which produces a silent gprinstall failure.
+    # Match instead on lines that carry a gnatcov-specific marker:
+    #   - "GNATcoverage <v>"   (canonical AdaCore output)
+    #   - "XCOV FSF <v>"       (older FSF/GPL output)
+    # Returns the major version from the first such line; falls back
+    # to None if no marker line is present (caller takes legacy path).
+    for line in output.splitlines():
+        if not re.search(r"GNATcoverage|XCOV", line):
+            continue
+        m = re.search(r"\b(\d+)\.\d+(?:\.\d+)?\b", line)
+        if m is not None:
+            return int(m.group(1))
+    return None
 
 
 def find_gnatcov_rts_source(root: Path) -> Path | None:

--- a/makefile/coverage_ada.py
+++ b/makefile/coverage_ada.py
@@ -209,23 +209,52 @@ def gnatcov_major_version(cwd: Path) -> int | None:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return None
 
+    # Layer 1: parse `gnatcov --version` output, scoped to lines that
+    # actually identify gnatcov. `re.search` over the combined buffer
+    # would pick up the FIRST `digits.digits(.digits)?` it sees, which
+    # on hosts where `alr exec` emits informational banners (e.g.
+    # "alr 2.1.0", "GNAT 15.2.1", "GPRBuild 25.0.1") before the gnatcov
+    # line resolves to those banners — and then the v22 legacy dispatch
+    # is taken against v26 runtime sources, producing a silent
+    # gprinstall failure. The marker is matched case-insensitively
+    # because actual v26 `gnatcov --version` output may use lower-case
+    # tool naming (and on some hosts the banner is the only text on
+    # stdout at all).
     output = (proc.stdout or "") + (proc.stderr or "")
-    # Isolate the version match to lines that actually identify gnatcov.
-    # `re.search` over the combined buffer would pick up the FIRST
-    # `digits.digits(.digits)?` it sees, which on hosts where `alr exec`
-    # emits informational banners (e.g. "alr 2.1.0", "GNAT 15.2.1",
-    # "GPRBuild 25.0.1") before the gnatcov line resolves to those
-    # banners — and then the v22 legacy dispatch is taken against v26
-    # runtime sources, which produces a silent gprinstall failure.
-    # Match instead on lines that carry a gnatcov-specific marker:
-    #   - "GNATcoverage <v>"   (canonical AdaCore output)
-    #   - "XCOV FSF <v>"       (older FSF/GPL output)
-    # Returns the major version from the first such line; falls back
-    # to None if no marker line is present (caller takes legacy path).
     for line in output.splitlines():
-        if not re.search(r"GNATcoverage|XCOV", line):
+        if not re.search(r"gnatcov|xcov", line, re.IGNORECASE):
             continue
         m = re.search(r"\b(\d+)\.\d+(?:\.\d+)?\b", line)
+        if m is not None:
+            return int(m.group(1))
+
+    # Layer 2: resolve the gnatcov binary path via `alr exec -- which
+    # gnatcov` and parse the major version from the Alire-managed
+    # install directory. Alire always installs releases under
+    #   .../alire/releases/<crate>_<major>.<minor>.<patch>_<sha>/
+    # so when the binary is provided by Alire (the normal case for
+    # crates that pin `gnatcov` as a test dep) the version is reliably
+    # encoded in the path. This is structurally bulletproof: it does
+    # not depend on the shape of `gnatcov --version` output, which has
+    # varied across releases. Reproduced as the second-order failure
+    # in adafmt run 25722225471 (2026-05-12): gnatcov 26.2.1 was
+    # resolved and installed, but its --version output did not contain
+    # any of the markers Layer 1 looks for, so Layer 1 returned None
+    # and the legacy dispatch was taken anyway.
+    try:
+        proc = subprocess.run(
+            ["alr", "exec", "--", "which", "gnatcov"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if proc.returncode == 0:
+        path = (proc.stdout or "").strip()
+        m = re.search(r"/gnatcov_(\d+)\.\d+\.\d+_", path)
         if m is not None:
             return int(m.group(1))
     return None

--- a/tests/test_coverage_ada_gnatcov_version.py
+++ b/tests/test_coverage_ada_gnatcov_version.py
@@ -49,6 +49,24 @@ def _make_completed_proc(returncode: int, stdout: str = "", stderr: str = ""):
         ("GNATcoverage 1.0\n", "", 1),
         ("no version anywhere here\n", "", None),
         ("", "", None),
+        # Regression: on hosts where `alr exec` emits informational
+        # banners before the gnatcov line (adafmt run 25720362926,
+        # 2026-05-12), the previous regex-on-combined-output
+        # implementation picked up the alr/toolchain version and
+        # mis-dispatched to the v22 legacy runtime-build path. The
+        # marker-based parser must skip those lines and return the
+        # version from the gnatcov line.
+        ("alr 2.1.0\nGNATcoverage 26.2.1 (b465e28d)\n", "", 26),
+        (
+            "alr 2.1.0\nDetected toolchain: GNAT 15.2.1\n"
+            "GPRBuild 25.0.1\nGNATcoverage 26.2.1\n",
+            "",
+            26,
+        ),
+        # No gnatcov marker anywhere — even though noise contains
+        # version-shaped strings, we cannot identify gnatcov's own
+        # version and must return None so the caller falls back.
+        ("alr 2.1.0\nDetected toolchain: GNAT 15.2.1\n", "", None),
     ],
 )
 def test_gnatcov_major_version_parses_typical_outputs(

--- a/tests/test_coverage_ada_gnatcov_version.py
+++ b/tests/test_coverage_ada_gnatcov_version.py
@@ -112,6 +112,120 @@ def test_gnatcov_major_version_parses_when_subprocess_returns_nonzero(
     assert got == 26
 
 
+# ---------------------------------------------------------------------------
+# Layer 2: Alire install-path fallback
+#
+# Reproduces the second-order failure surfaced in adafmt run 25722225471
+# (2026-05-12): the marker regex in Layer 1 correctly skipped the alr
+# banner, but gnatcov 26.2.1's `--version` output did not contain any
+# of the recognized markers, so Layer 1 returned None and the legacy
+# dispatch fired anyway. Layer 2 resolves the binary path via
+# `alr exec -- which gnatcov` and parses the version from the
+# Alire-managed install directory:
+#   .../alire/releases/gnatcov_<major>.<minor>.<patch>_<sha>/bin/gnatcov
+# ---------------------------------------------------------------------------
+
+
+def test_gnatcov_major_version_falls_back_to_alire_path_on_unparseable_version_output(
+    tmp_path: Path,
+) -> None:
+    """Layer 1 misses (no marker / no version line); Layer 2 picks up
+    the major version from the Alire install path."""
+    with patch.object(coverage_ada.subprocess, "run") as mock_run:
+        mock_run.side_effect = [
+            # Call 1: gnatcov --version — empty / unparseable output
+            _make_completed_proc(0, stdout="", stderr=""),
+            # Call 2: which gnatcov — versioned Alire install path
+            _make_completed_proc(
+                0,
+                stdout="/home/runner/.local/share/alire/releases/"
+                "gnatcov_26.2.1_b465e28d/bin/gnatcov\n",
+                stderr="",
+            ),
+        ]
+        got = coverage_ada.gnatcov_major_version(tmp_path)
+    assert got == 26
+
+
+def test_gnatcov_major_version_layer2_when_version_output_has_unrelated_banners_only(
+    tmp_path: Path,
+) -> None:
+    """Reproduces the exact run-25722225471 shape: `gnatcov --version`
+    emits only an unrelated banner (no gnatcov / xcov marker line), so
+    Layer 1 returns None, and Layer 2 must consult the Alire path."""
+    with patch.object(coverage_ada.subprocess, "run") as mock_run:
+        mock_run.side_effect = [
+            _make_completed_proc(
+                0,
+                stdout="alr 2.1.0\nDetected toolchain: GNAT 15.2.1\n",
+                stderr="",
+            ),
+            _make_completed_proc(
+                0,
+                stdout="/home/runner/.local/share/alire/releases/"
+                "gnatcov_26.2.1_b465e28d/bin/gnatcov\n",
+                stderr="",
+            ),
+        ]
+        got = coverage_ada.gnatcov_major_version(tmp_path)
+    assert got == 26
+
+
+def test_gnatcov_major_version_returns_none_when_neither_layer_succeeds(
+    tmp_path: Path,
+) -> None:
+    """Both probes fail to identify a version → None, so the caller
+    takes the legacy path with the existing
+    'Could not determine gnatcov major version' warning. Notably,
+    `which gnatcov` may return a non-Alire path (e.g. /usr/bin/gnatcov)
+    that contains no version — Layer 2 must return None for that
+    case, not invent a version."""
+    with patch.object(coverage_ada.subprocess, "run") as mock_run:
+        mock_run.side_effect = [
+            _make_completed_proc(0, stdout="", stderr=""),
+            _make_completed_proc(0, stdout="/usr/bin/gnatcov\n", stderr=""),
+        ]
+        got = coverage_ada.gnatcov_major_version(tmp_path)
+    assert got is None
+
+
+def test_gnatcov_major_version_prefers_layer1_when_both_could_resolve(
+    tmp_path: Path,
+) -> None:
+    """When Layer 1 finds a version, Layer 2 is not consulted. This
+    matters if the Alire cache happens to hold an older crate version
+    while the active `gnatcov --version` reports a newer one — Layer 1
+    is the truth source for the actually-invoked binary."""
+    with patch.object(coverage_ada.subprocess, "run") as mock_run:
+        mock_run.side_effect = [
+            _make_completed_proc(0, "GNATcoverage 26.2.1\n", ""),
+            # If Layer 2 were called erroneously, this would yield 22.
+            _make_completed_proc(
+                0,
+                stdout="/path/to/gnatcov_22.0.1_xxx/bin/gnatcov\n",
+                stderr="",
+            ),
+        ]
+        got = coverage_ada.gnatcov_major_version(tmp_path)
+    assert got == 26
+
+
+def test_gnatcov_major_version_layer2_returns_none_when_which_fails(
+    tmp_path: Path,
+) -> None:
+    """If `which gnatcov` returns non-zero (e.g. gnatcov not on PATH),
+    Layer 2 returns None rather than parsing whatever stderr says."""
+    with patch.object(coverage_ada.subprocess, "run") as mock_run:
+        mock_run.side_effect = [
+            _make_completed_proc(0, stdout="", stderr=""),
+            _make_completed_proc(
+                1, stdout="", stderr="which: no gnatcov in (...)\n",
+            ),
+        ]
+        got = coverage_ada.gnatcov_major_version(tmp_path)
+    assert got is None
+
+
 def test_gnatcov_rts_implicit_with_prefers_full_when_present(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Make `gnatcov_major_version()` in `makefile/coverage_ada.py` reliably identify the GNATcoverage version even when `alr exec -- gnatcov --version`'s output is preceded by other version-shaped strings (alr banners, toolchain notices) or doesn't contain the canonical `GNATcoverage`/`XCOV` markers at all.

Reproduced as a multi-stage failure in adafmt run 25720362926 (2026-05-12) and adafmt run 25722225471 (2026-05-12). End-to-end verification: adafmt run 25778594041 (2026-05-13) — both Linux cells PASS coverage with the layered detection in place; NFR-08.4 verified across Domain (100 %), Application (93.88 %), Infrastructure (76.83 %).

## Two commits in this PR

### `42c8386` — Layer 1: marker-regex fix

Previous implementation: `re.search(r"\b(\d+)\.\d+(?:\.\d+)?\b", output)` against combined stdout+stderr. `re.search` returns the **first** match, so on hosts where `alr exec` (or the toolchain) emits any version-shaped string before the gnatcov line — e.g. an `alr 2.1.0` banner, a `Detected toolchain: GNAT 15.2.1` notice, or a `GPRBuild 25.0.1` line — the helper returned 2 / 15 / 25 instead of 26 and dispatched to the wrong runtime-build path.

Fix: iterate the output line by line and only accept a version match from a line carrying a gnatcov-specific marker — either canonical AdaCore `GNATcoverage <v>` or older FSF/GPL `XCOV FSF <v>`. Lines without a marker are skipped.

### `deecf79` — Layer 2: Alire install-path fallback

Layer 1 alone wasn't enough: gnatcov 26.2.1's actual `--version` output on GHA Linux runners contained no `GNATcoverage` or `XCOV` marker, so the helper returned `None` and the legacy dispatch fired anyway. The marker-only Layer 1 is brittle to gnatcov-release output-format changes.

Fix: when Layer 1 returns `None`, resolve the gnatcov binary path via `alr exec -- which gnatcov` and parse the major version from the Alire-managed install directory, which is ALWAYS shaped as:

```
.../alire/releases/gnatcov_<major>.<minor>.<patch>_<sha>/bin/gnatcov
```

This is structurally bulletproof — it does not depend on the shape of `gnatcov --version` output, which has varied across releases. Layer 1 is preferred (active-binary truth source) and only when it returns `None` does Layer 2 consult the install path.

Also broadens Layer 1's marker regex to case-insensitive and adds `gnatcov` itself (in addition to `GNATcoverage` and `XCOV`) so future releases that lower-case the tool name are covered.

## Tests

`tests/test_coverage_ada_gnatcov_version.py` — extended:

- 3 new regression cases for Layer 1 in the parametrized suite (banner + gnatcov line, multi-banner + gnatcov line, banner-only → None).
- 5 new cases for Layer 2 (unparseable version output + versioned alire path, banner-only version output + versioned alire path matching run 25722225471's reproduction, both probes return None, Layer 1 wins when both could resolve, `which` returns non-zero → None).

All 23 cases pass; full repo suite (78 tests across 4 files) passes:

```
$ pytest tests/test_coverage_ada_gnatcov_version.py
================== 23 passed in 0.11s ===================
$ pytest
================== 78 passed in 0.32s ===================
```

## Cross-consumer impact

Affects all five consumers of the shared `coverage_ada.py`:

- **adafmt** — verified end-to-end on run 25778594041 (NFR-08.4 PASS).
- **astfmt** — already pinned to `gnatcov ^26`; will benefit on next coverage dispatch.
- **astengine**, **clara**, **functional** — currently pinned to `gnatcov ^22.0.1`; will benefit when they bump.

## Refs

- adafmt#67 — v1.0.0 execution board (NFR-08.4 line item, now verified)
- adafmt#98 — adafmt-side scaffolding + TR12–TR52 release-hardening batch