### PR TITLE
feat(package_dist): add --tarball / --include-docs / --strict-system-deps

### DIFF
--- a/package_dist/package_dist.py
+++ b/package_dist/package_dist.py
@@ -2,7 +2,7 @@
 """
 package_dist.py — Build + create relocatable dist/ bundle for an Alire GNAT Ada CLI.
 
-Features:
+Core features:
 - Auto-detect binary name from ./bin if exactly one executable (else require --bin-name).
 - Auto-run a /tmp smoke test and print PASS/FAIL.
 - Linux: bundle only missing shared libs ("=> not found") by searching Alire toolchains.
@@ -11,27 +11,65 @@ Features:
 - macOS: always run `install_name_tool -add_rpath @executable_path/../lib dist/bin/<exe>` (harmless if already present).
 - Smoke test: supports "usage-style" CLIs that exit non-zero when printing usage.
 
-Default layout:
+Release-packaging features:
+- --tarball <basename> (REQUIRED): stage under dist/<basename>/, produce
+  <project>/<basename>.tar.gz containing the single top-level <basename>/
+  directory, emit <project>/<basename>.tar.gz.sha256 in sha256sum-compatible
+  format, run a manifest allow-set check against the tarball contents, and
+  stream the final `tar -tzf` listing to stdout for workflow-log visibility.
+  macOS AppleDouble/resource-fork files (._*, .DS_Store) and xattr-derived
+  metadata are excluded.
+- --include-docs <comma-separated paths> (optional): copy named project-root
+  docs into the staged tree.  Missing files fail (no silent skipping) —
+  release artifacts must not ship without their required documentation.
+- --strict-system-deps (optional): Linux only.  After bundling, verify the
+  binary's dynamic dependencies match a narrow system-library allowlist; fail
+  on any unexpected entry.  Three success paths: (a) dynamic binary with only
+  allowlisted system deps, (b) fully/static-mostly binary reporting "not a
+  dynamic executable" / "statically linked", (c) parsed-as-empty NEEDED list.
+  Prefers `readelf -d` for NEEDED entries; falls back to `ldd` parsing.
+
+Layout:
   project/
     bin/<exe>
-    dist/
+    dist/<basename>/
       bin/<exe>
-      lib/(runtime libs)
+      lib/(runtime libs, if any)
+      LICENSE                       # if --include-docs lists it
+      THIRD_PARTY_LICENSES.md
+      README.md
+      CHANGELOG.md
+    <basename>.tar.gz
+    <basename>.tar.gz.sha256
 
 Usage:
-  python3 package_dist.py
-  python3 package_dist.py --bin-name adafmt
-  python3 package_dist.py --no-build
-  python3 package_dist.py --test-args ""               # run with no args (usage output)
-  python3 package_dist.py --test-args "--help"         # if your CLI supports it
-  python3 package_dist.py --codesign                   # macOS only
-  python3 package_dist.py --expect-exit 1              # force expected exit code
-  python3 package_dist.py --pass-if-stdout-contains "Usage:"  # auto-pass if output contains substring
+  python3 package_dist.py --tarball adafmt-1.0.0-rc1-linux-amd64
+  python3 package_dist.py --tarball adafmt-1.0.0-rc1-linux-amd64 \
+    --include-docs LICENSE,THIRD_PARTY_LICENSES.md,README.md,CHANGELOG.md \
+    --strict-system-deps
+  python3 package_dist.py --tarball <basename> --bin-name adafmt --no-build
+  python3 package_dist.py --tarball <basename> --test-args "--help" --expect-exit 0
+  python3 package_dist.py --tarball <basename> --codesign  # macOS only
+
+Exit codes:
+  0  success
+  1  generic failure (also: smoke test FAIL when --expect-exit not given and no marker matched)
+  2  missing alire.toml in --project-dir
+  3  alr build failed
+  4  --bin-name auto-detect ambiguous
+  5  binary not found in bin/
+  6  Linux ldd bundling still reports missing deps after copy pass
+  7  unsupported platform
+  8  smoke test FAIL with --expect-exit / explicit pass-marker mismatch
+  9  --strict-system-deps allowlist violation
+  10 --include-docs missing a named file
+  11 --tarball creation or sha256 step failed
+  12 --tarball manifest check found an unexpected entry
 
 Notes:
-- Linux relies on: ldd
-- macOS relies on: otool, install_name_tool (Xcode CLI tools)
-- macOS codesign (optional): codesign
+- Linux relies on: ldd, readelf (preferred for NEEDED parsing), tar, sha256sum.
+- macOS relies on: otool, install_name_tool (Xcode CLI tools), tar, shasum or sha256sum.
+- macOS codesign (optional): codesign.
 """
 
 from __future__ import annotations
@@ -48,6 +86,26 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 ALIRE_TOOLCHAINS_DEFAULT = Path.home() / ".local" / "share" / "alire" / "toolchains"
+
+
+# Linux system-library allowlist for --strict-system-deps.  Matched against
+# the soname (basename) reported by readelf NEEDED / ldd, not against the
+# resolved absolute path.  Keeping this narrow is intentional: anything else
+# entering the closure is treated as a release-blocking surprise.
+ALLOWED_SYSTEM_DEPS = [
+    re.compile(r'^libc\.so\.[0-9]+$'),
+    re.compile(r'^libm\.so\.[0-9]+$'),
+    re.compile(r'^libdl\.so\.[0-9]+$'),
+    re.compile(r'^libpthread\.so\.[0-9]+$'),
+    re.compile(r'^librt\.so\.[0-9]+$'),
+    re.compile(r'^libgcc_s\.so\.[0-9]+$'),
+    re.compile(r'^ld-linux(-aarch64|-x86-64)?\.so\.[0-9]+$'),
+    re.compile(r'^linux-vdso\.so\.[0-9]+$'),
+]
+
+# macOS metadata patterns excluded from tarballs (and stripped from the
+# staged tree before tarring when running on a macOS host).
+MACOS_METADATA_EXCLUDES = ('._*', '.DS_Store')
 
 
 # -------------------------
@@ -368,6 +426,307 @@ def macos_codesign_dist(dist_dir: Path) -> None:
 
 
 # -------------------------
+# Release-packaging helpers
+# -------------------------
+
+def include_docs_into_stage(stage_root: Path, project: Path, doc_list: List[str]) -> int:
+    """
+    Copy each named project-root doc into the staged tree at stage_root/.
+    Fails with exit 10 on any missing file — release artifacts must not
+    ship without their required documentation.
+    Returns 0 on success or the exit code on failure.
+    """
+    banner("Include required docs")
+    missing: List[Path] = []
+    for name in doc_list:
+        src = (project / name).resolve()
+        if not src.is_file():
+            missing.append(src)
+            print(f"! Required doc not found: {src}")
+            continue
+        dst = stage_root / src.name
+        shutil.copy2(src, dst)
+        print(f"  - Copied: {src} -> {dst}")
+    if missing:
+        print(f"! --include-docs: {len(missing)} required doc(s) missing; failing.")
+        return 10
+    return 0
+
+
+def strip_macos_metadata(stage_root: Path) -> None:
+    """
+    On a macOS host, strip extended attributes from the staged tree and
+    remove any AppleDouble (`._*`) or `.DS_Store` files that may have
+    landed during copy.  No-op on non-Darwin hosts (but still walks the
+    tree to remove any of those files if they exist, since they could
+    have been carried in via a network/USB share).
+    """
+    if platform.system().lower() == "darwin" and which("xattr"):
+        run_noexcept(["xattr", "-c", "-r", str(stage_root)])
+        print("  - macOS: stripped xattrs from staged tree.")
+
+    removed = 0
+    for p in stage_root.rglob("._*"):
+        if p.is_file():
+            try:
+                p.unlink()
+                removed += 1
+            except OSError:
+                pass
+    for p in stage_root.rglob(".DS_Store"):
+        if p.is_file():
+            try:
+                p.unlink()
+                removed += 1
+            except OSError:
+                pass
+    if removed:
+        print(f"  - Removed {removed} macOS metadata file(s) from staged tree.")
+
+
+# ---- Linux strict-system-deps -------------------------------------------------
+
+_READELF_NEEDED_RE = re.compile(
+    r"\(NEEDED\)\s+Shared library:\s+\[(?P<soname>[^\]]+)\]"
+)
+
+# Matches any of:
+#   "linux-vdso.so.1 (0xADDR)"        — vDSO, no `=>`
+#   "libc.so.6 => /lib/.../libc.so.6 (0xADDR)" — regular dep
+#   "/lib64/ld-linux-x86-64.so.2 (0xADDR)" — dynamic loader, absolute
+# Captures the soname (basename) for allowlist matching.
+_LDD_ANY_RE = re.compile(
+    r"^\s*"
+    r"(?:(?P<soname>\S+)\s+=>\s+\S+|"            # name => path
+    r"(?P<vdso>\S+)\s+\(0x[0-9a-fA-F]+\)|"        # name (addr)   — vdso
+    r"(?P<absloader>/\S+)\s+\(0x[0-9a-fA-F]+\))"  # /path (addr)  — loader
+)
+
+# Detect "not a dynamic executable" / "statically linked" via lowercased substring
+# scan — output text differs across libc versions (musl, glibc) and locales.
+_LDD_STATIC_HINTS = (
+    "not a dynamic executable",
+    "statically linked",
+)
+
+
+def parse_readelf_needed(output: str) -> List[str]:
+    """Return the soname list from `readelf -d <binary>` output."""
+    return _READELF_NEEDED_RE.findall(output)
+
+
+def parse_ldd_sonames(output: str) -> Tuple[List[str], bool]:
+    """
+    Parse `ldd <binary>` output.
+    Returns (list_of_sonames_basenames, is_statically_linked).
+    The soname list normalizes absolute-path loader entries to their basename.
+    """
+    lowered = output.lower()
+    if any(hint in lowered for hint in _LDD_STATIC_HINTS):
+        return [], True
+
+    sonames: List[str] = []
+    for line in output.splitlines():
+        m = _LDD_ANY_RE.match(line)
+        if not m:
+            continue
+        name = m.group("soname") or m.group("vdso") or m.group("absloader") or ""
+        if not name:
+            continue
+        # Normalize absolute loader path to basename for allowlist match.
+        if name.startswith("/"):
+            name = Path(name).name
+        sonames.append(name)
+    return sonames, False
+
+
+def _allowlist_matches(soname: str) -> bool:
+    return any(rx.match(soname) for rx in ALLOWED_SYSTEM_DEPS)
+
+
+def enforce_strict_system_deps(binary: Path) -> int:
+    """
+    Linux only.  Verify the binary's dynamic dependency closure matches
+    ALLOWED_SYSTEM_DEPS.  Prefers `readelf -d`; falls back to `ldd`.
+    Returns 0 on success, 9 on disallowed entries.
+
+    Three success paths:
+      (a) dynamic binary, every NEEDED soname is in ALLOWED_SYSTEM_DEPS.
+      (b) statically-linked binary (ldd "not a dynamic executable" /
+          "statically linked").
+      (c) parsed-as-empty NEEDED list (both readelf and ldd report no deps).
+    """
+    banner("Strict system-deps check")
+
+    sonames: List[str] = []
+    used_tool = ""
+
+    if which("readelf"):
+        cp = run_noexcept(["readelf", "-d", str(binary)])
+        if cp.returncode == 0:
+            sonames = parse_readelf_needed(cp.stdout)
+            used_tool = "readelf"
+            print(f"  - readelf NEEDED: {sonames if sonames else '(empty)'}")
+        else:
+            # readelf failed (not an ELF? cross-platform binary?) — fall through to ldd.
+            print(f"  - readelf failed (exit {cp.returncode}); trying ldd.")
+
+    if used_tool != "readelf":
+        if not which("ldd"):
+            print("! Neither readelf nor ldd is available; cannot verify deps.")
+            return 9
+        cp = run_noexcept(["ldd", str(binary)])
+        # ldd typically exits 0 for dynamic binaries and 1 for "not a dynamic
+        # executable"; both are inspected.  Stdout+stderr are combined because
+        # static binaries often print the message on stderr.
+        combined = (cp.stdout or "") + "\n" + (cp.stderr or "")
+        sonames, is_static = parse_ldd_sonames(combined)
+        used_tool = "ldd"
+        if is_static:
+            print("  - ldd: binary is statically linked (not a dynamic executable).")
+            print("  - strict-system-deps: PASS (static binary).")
+            return 0
+        print(f"  - ldd sonames: {sonames if sonames else '(empty)'}")
+
+    if not sonames:
+        print(f"  - {used_tool}: empty NEEDED list.")
+        print("  - strict-system-deps: PASS (no dynamic deps).")
+        return 0
+
+    disallowed = [s for s in sonames if not _allowlist_matches(s)]
+    if disallowed:
+        print("! strict-system-deps: disallowed deps:")
+        for d in disallowed:
+            print(f"    - {d}")
+        print(f"  - allowlist: {[rx.pattern for rx in ALLOWED_SYSTEM_DEPS]}")
+        return 9
+
+    print("  - strict-system-deps: PASS (all deps allowlisted).")
+    return 0
+
+
+# ---- Tarball + sha256 + manifest -----------------------------------------------
+
+def create_tarball(dist_dir: Path, basename: str, output_dir: Path) -> Tuple[Path, int]:
+    """
+    Create <output_dir>/<basename>.tar.gz containing the single top-level
+    directory <basename>/ from <dist_dir>/<basename>/.
+    Excludes macOS AppleDouble (._*) and .DS_Store files.
+    Returns (tarball_path, exit_code).  exit_code = 0 on success, 11 on failure.
+    """
+    banner("Create tarball")
+    tarball = output_dir / f"{basename}.tar.gz"
+
+    cmd = [
+        "tar",
+        "--exclude=._*",
+        "--exclude=.DS_Store",
+        "-C", str(dist_dir),
+        "-czf", str(tarball),
+        basename,
+    ]
+    cp = run_noexcept(cmd)
+    if cp.returncode != 0:
+        if cp.stdout.strip():
+            print(cp.stdout.rstrip())
+        if cp.stderr.strip():
+            print(cp.stderr.rstrip(), file=sys.stderr)
+        print(f"! tar failed (exit {cp.returncode}); failing.")
+        return tarball, 11
+
+    if not tarball.is_file():
+        print(f"! tar reported success but {tarball} is missing; failing.")
+        return tarball, 11
+
+    print(f"  - Created: {tarball}")
+    return tarball, 0
+
+
+def write_sha256(tarball: Path) -> Tuple[Path, int]:
+    """
+    Emit <tarball>.sha256 in sha256sum-compatible format
+    (`<hash>  <filename>`).  Filename is the basename only so the
+    file works regardless of where consumers download it.
+    Returns (sha_path, exit_code).
+    """
+    sha_path = tarball.with_name(tarball.name + ".sha256")
+    try:
+        import hashlib
+        h = hashlib.sha256()
+        with tarball.open("rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                h.update(chunk)
+        digest = h.hexdigest()
+        sha_path.write_text(f"{digest}  {tarball.name}\n", encoding="utf-8")
+        print(f"  - Wrote: {sha_path}")
+        print(f"  - sha256: {digest}")
+        return sha_path, 0
+    except OSError as exc:
+        print(f"! sha256 emission failed: {exc}")
+        return sha_path, 11
+
+
+def expected_manifest_entries(basename: str, bin_name: str,
+                              doc_list: List[str],
+                              bundled_lib_names: List[str]) -> set:
+    """
+    Build the allow-set of expected tar -tzf entries.  tar lists directories
+    with a trailing slash and files without.  The expected set always includes
+    the top-level <basename>/ directory and <basename>/bin/<exe>; the lib/
+    directory and its entries are included only if any libs were bundled; each
+    --include-docs entry is included as <basename>/<doc>.
+    """
+    expected: set = set()
+    expected.add(f"{basename}/")
+    expected.add(f"{basename}/bin/")
+    expected.add(f"{basename}/bin/{bin_name}")
+    if bundled_lib_names:
+        expected.add(f"{basename}/lib/")
+        for libname in bundled_lib_names:
+            expected.add(f"{basename}/lib/{libname}")
+    for doc in doc_list:
+        # Basename only — --include-docs flattens names to stage_root/.
+        expected.add(f"{basename}/{Path(doc).name}")
+    return expected
+
+
+def verify_tarball_manifest(tarball: Path,
+                            expected: set) -> Tuple[List[str], int]:
+    """
+    Run `tar -tzf <tarball>`, log every entry to stdout (workflow-log
+    manifest visibility), and verify no entry falls outside `expected`.
+    Returns (listing, exit_code).  exit_code = 0 on success, 12 on
+    unexpected entries.
+    """
+    banner("Manifest check (tar -tzf)")
+    cp = run_noexcept(["tar", "-tzf", str(tarball)])
+    if cp.returncode != 0:
+        print(f"! tar -tzf failed (exit {cp.returncode}); failing.")
+        return [], 12
+
+    listing = [line for line in cp.stdout.splitlines() if line.strip()]
+    for entry in listing:
+        print(f"    {entry}")
+
+    # tar may also emit an implicit "<basename>/lib/" entry only if a lib
+    # directory is non-empty.  An empty lib/ directory should not appear; if
+    # the strict gate above produced an empty lib/, the staging step removes
+    # it before tarring (see clean_empty_lib_dir below in main()).
+    unexpected = [e for e in listing if e not in expected]
+    if unexpected:
+        print("! Manifest contains unexpected entries (not in allow-set):")
+        for u in unexpected:
+            print(f"    + {u}")
+        print(f"  - expected allow-set ({len(expected)} entries):")
+        for e in sorted(expected):
+            print(f"    = {e}")
+        return listing, 12
+
+    print(f"  - Manifest OK ({len(listing)} entries, all within allow-set).")
+    return listing, 0
+
+
+# -------------------------
 # /tmp smoke test
 # -------------------------
 
@@ -407,17 +766,19 @@ def smoke_test(exe_path: Path, test_args: List[str], expect_exit: Optional[int],
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--project-dir", type=Path, default=Path.cwd(), help="Project root containing alire.toml")
-    ap.add_argument("--bin-name", default=None, help="Executable name under bin/ (auto-detect if omitted)")
-    ap.add_argument("--dist-dir", type=Path, default=None, help="Output dist directory (default: <project>/dist)")
+    ap.add_argument("--project-dir", type=Path, default=Path.cwd(),
+                    help="Project root containing alire.toml")
+    ap.add_argument("--bin-name", default=None,
+                    help="Executable name under bin/ (auto-detect if omitted)")
+    ap.add_argument("--dist-dir", type=Path, default=None,
+                    help="Output dist directory (default: <project>/dist)")
     ap.add_argument("--no-build", action="store_true", help="Skip alr build step")
     ap.add_argument("--alire-toolchains", type=Path, default=ALIRE_TOOLCHAINS_DEFAULT,
                     help="Alire toolchains root (default: ~/.local/share/alire/toolchains)")
 
-    # Smoke test defaults updated:
-    # - default test args: "" (run with no args)
-    # - default pass marker: "Usage:" (treat usage output as success)
-    ap.add_argument("--test-args", default="", help='Args to run in smoke test (default: "")')
+    # Smoke-test args.
+    ap.add_argument("--test-args", default="",
+                    help='Args to run in smoke test (default: "")')
     ap.add_argument("--no-test", action="store_true", help="Skip /tmp smoke test")
     ap.add_argument("--expect-exit", type=int, default=None,
                     help="Treat this exit code as success for the smoke test (default: auto)")
@@ -426,11 +787,27 @@ def main() -> int:
 
     ap.add_argument("--codesign", action="store_true", help="macOS only: ad-hoc codesign dist/")
 
+    # Release-packaging flags.
+    ap.add_argument("--tarball", required=True, metavar="BASENAME",
+                    help="Basename for the produced tarball (e.g. adafmt-1.0.0-rc1-linux-amd64). "
+                         "The script stages under dist/<basename>/ and emits "
+                         "<project>/<basename>.tar.gz plus <basename>.tar.gz.sha256.")
+    ap.add_argument("--include-docs", default="",
+                    help="Comma-separated list of project-root files to copy into the staged "
+                         "tree (e.g. LICENSE,THIRD_PARTY_LICENSES.md,README.md,CHANGELOG.md). "
+                         "Missing files fail (no silent skipping).")
+    ap.add_argument("--strict-system-deps", action="store_true",
+                    help="Linux only: after bundling, verify the binary's dynamic dependency "
+                         "closure matches the ALLOWED_SYSTEM_DEPS allowlist.  Fails on any "
+                         "unexpected entry.")
+
     args = ap.parse_args()
 
     project = args.project_dir.resolve()
     dist = (args.dist_dir.resolve() if args.dist_dir else (project / "dist"))
     bin_dir = project / "bin"
+    basename = args.tarball
+    doc_list = [d.strip() for d in args.include_docs.split(",") if d.strip()]
 
     if not (project / "alire.toml").exists():
         return fail(f"Expected alire.toml in {project}", 2)
@@ -438,7 +815,6 @@ def main() -> int:
     # Build
     if not args.no_build:
         banner("Build")
-        # Match your typical command pattern
         cp = run_noexcept(["alr", "build", "--release", "--", "-j0"], cwd=project)
         if cp.stdout.strip():
             print(cp.stdout.rstrip())
@@ -467,11 +843,12 @@ def main() -> int:
     if not src_bin.exists():
         return fail(f"Binary not found: {src_bin}", 5)
 
-    # Create dist layout + copy binary
-    dist_bin = dist / "bin"
-    dist_lib = dist / "lib"
+    # Stage under dist/<basename>/ — single layout, no flat-dist legacy mode.
+    stage_root = dist / basename
+    dist_bin = stage_root / "bin"
+    dist_lib = stage_root / "lib"
 
-    banner("Stage dist/")
+    banner(f"Stage dist/{basename}/")
     if dist.exists():
         shutil.rmtree(dist)
     ensure_dir(dist_bin)
@@ -491,13 +868,14 @@ def main() -> int:
         if not ok:
             return fail(f"Still missing deps after bundling: {missing}", 6)
 
+        if args.strict_system_deps:
+            rc = enforce_strict_system_deps(dst_bin)
+            if rc != 0:
+                return rc
+
     elif sysname == "darwin":
         banner("macOS rpath + bundle")
-
-        # Run the exact requested command (harmless if already present):
         macos_add_dist_rpath(dst_bin)
-
-        # Bundle dylibs and rewrite to @rpath
         macos_copy_needed_dylibs(dst_bin, dist_lib)
         macos_rewrite_to_rpath(dst_bin, dist_lib)
 
@@ -506,24 +884,59 @@ def main() -> int:
         print(cp.stdout.rstrip())
 
         if args.codesign:
-            macos_codesign_dist(dist)
+            macos_codesign_dist(stage_root)
 
     else:
         return fail(f"Unsupported platform: {platform.system()}", 7)
 
-    # Smoke test
+    # Required docs (fail-on-missing).
+    if doc_list:
+        rc = include_docs_into_stage(stage_root, project, doc_list)
+        if rc != 0:
+            return rc
+
+    # Remove empty lib/ directory so the manifest does not list an empty
+    # tar entry for it (static-link builds produce no bundled libs).
+    bundled_lib_names: List[str] = []
+    if dist_lib.is_dir():
+        bundled_lib_names = sorted(p.name for p in dist_lib.iterdir() if p.is_file())
+        if not bundled_lib_names:
+            try:
+                dist_lib.rmdir()
+                print(f"  - Removed empty staged lib/ directory (no bundled libs).")
+            except OSError:
+                pass
+
+    # Strip macOS metadata before tarring (no-op on non-Darwin hosts unless
+    # someone copied a file with `._*` / `.DS_Store` into the staged tree).
+    strip_macos_metadata(stage_root)
+
+    # Smoke test against the staged binary BEFORE tarring so a broken binary
+    # short-circuits before producing a release artifact.
     if not args.no_test:
         test_args = args.test_args.split() if args.test_args.strip() else []
         ok = smoke_test(dst_bin, test_args, args.expect_exit, args.pass_if_stdout_contains)
         if not ok:
             return 8
 
+    # Tarball + sha256 + manifest check + log listing.
+    tarball, rc = create_tarball(dist, basename, project)
+    if rc != 0:
+        return rc
+
+    _sha_path, rc = write_sha256(tarball)
+    if rc != 0:
+        return rc
+
+    expected = expected_manifest_entries(basename, bin_name, doc_list, bundled_lib_names)
+    _listing, rc = verify_tarball_manifest(tarball, expected)
+    if rc != 0:
+        return rc
+
     banner("DONE ✅")
-    print(f"dist folder: {dist}")
-    if args.test_args.strip():
-        print(f"run from anywhere: {dst_bin} {args.test_args}")
-    else:
-        print(f"run from anywhere: {dst_bin}")
+    print(f"stage:   {stage_root}")
+    print(f"tarball: {tarball}")
+    print(f"sha256:  {tarball.name}.sha256")
     return 0
 
 

--- a/tests/test_package_dist.py
+++ b/tests/test_package_dist.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+"""Unit tests for ``package_dist.package_dist`` release-packaging helpers.
+
+Covers (per adafmt#62 RC-1 packaging design):
+
+- ALLOWED_SYSTEM_DEPS allowlist regex behavior on good and poisoned inputs.
+- ``parse_readelf_needed`` parses NEEDED entries from ``readelf -d`` output.
+- ``parse_ldd_sonames`` parses dynamic deps and detects "not a dynamic
+  executable" / "statically linked".
+- ``include_docs_into_stage`` copies named docs and fails on missing files.
+- ``create_tarball`` + ``write_sha256`` produce a top-level-dir tarball and
+  matching sha256sum-compatible file; round-trip verified with
+  ``sha256sum -c`` semantics (recomputed in-test).
+- ``expected_manifest_entries`` allow-set shape.
+- ``verify_tarball_manifest`` accepts allowed contents and rejects extras.
+
+Fixtures use ``tmp_path``; no subprocess invocations are made beyond the
+real ``tar`` and (where available) ``sha256sum`` shell tools, which are
+standard on macOS and Linux runners alike.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# package_dist lives one level down; conftest already inserted repo root.
+from package_dist.package_dist import (
+    ALLOWED_SYSTEM_DEPS,
+    _allowlist_matches,
+    create_tarball,
+    expected_manifest_entries,
+    include_docs_into_stage,
+    parse_ldd_sonames,
+    parse_readelf_needed,
+    verify_tarball_manifest,
+    write_sha256,
+)
+
+
+# ----------------------------------------------------------------------
+# Allowlist
+# ----------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "soname",
+    [
+        "libc.so.6",
+        "libm.so.6",
+        "libdl.so.2",
+        "libpthread.so.0",
+        "librt.so.1",
+        "libgcc_s.so.1",
+        "ld-linux-x86-64.so.2",
+        "ld-linux-aarch64.so.1",
+        "ld-linux.so.2",
+        "linux-vdso.so.1",
+    ],
+)
+def test_allowlist_accepts_system_sonames(soname):
+    assert _allowlist_matches(soname), f"{soname!r} should be allowlisted"
+
+
+@pytest.mark.parametrize(
+    "soname",
+    [
+        "libcrypto.so.3",
+        "libssl.so.3",
+        "libgnatcoll.so.26",
+        "libstdc++.so.6",
+        "libiconv.so.2",
+        "libz.so.1",
+        "evil.so",
+        "libc.so",                       # missing version suffix
+        "libc.so.6.1",                    # extra version segment
+        "libfoo-libc.so.6",               # name not anchored at start
+    ],
+)
+def test_allowlist_rejects_unexpected_sonames(soname):
+    assert not _allowlist_matches(soname), f"{soname!r} must NOT be allowlisted"
+
+
+def test_allowlist_count_is_locked():
+    # Sanity check: if someone broadens the allowlist they must update
+    # this test, which forces a deliberate review.  Current allowlist
+    # entries: libc, libm, libdl, libpthread, librt, libgcc_s, ld-linux,
+    # linux-vdso.
+    assert len(ALLOWED_SYSTEM_DEPS) == 8
+
+
+# ----------------------------------------------------------------------
+# readelf parsing
+# ----------------------------------------------------------------------
+
+READELF_SAMPLE_DYNAMIC = """\
+Dynamic section at offset 0x1234 contains 28 entries:
+  Tag        Type                         Name/Value
+ 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
+ 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
+ 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
+ 0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
+ 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
+ 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
+ 0x000000000000000c (INIT)               0x4010
+"""
+
+READELF_SAMPLE_POISONED = """\
+ 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
+ 0x0000000000000001 (NEEDED)             Shared library: [libcrypto.so.3]
+"""
+
+READELF_SAMPLE_EMPTY = """\
+Dynamic section at offset 0x0 contains 0 entries:
+"""
+
+
+def test_parse_readelf_needed_dynamic():
+    got = parse_readelf_needed(READELF_SAMPLE_DYNAMIC)
+    assert got == [
+        "libgcc_s.so.1", "libpthread.so.0", "libdl.so.2",
+        "librt.so.1", "libm.so.6", "libc.so.6",
+    ]
+
+
+def test_parse_readelf_needed_poisoned():
+    got = parse_readelf_needed(READELF_SAMPLE_POISONED)
+    assert "libcrypto.so.3" in got
+
+
+def test_parse_readelf_needed_empty():
+    assert parse_readelf_needed(READELF_SAMPLE_EMPTY) == []
+
+
+# ----------------------------------------------------------------------
+# ldd parsing
+# ----------------------------------------------------------------------
+
+LDD_SAMPLE_DYNAMIC = """\
+\tlinux-vdso.so.1 (0x00007ffe2c5fe000)
+\tlibgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f1)
+\tlibc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2)
+\t/lib64/ld-linux-x86-64.so.2 (0x00007f3)
+"""
+
+LDD_SAMPLE_DYNAMIC_AARCH64 = """\
+\tlinux-vdso.so.1 (0x0000ffff9c5fe000)
+\tlibc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffff9c500000)
+\t/lib/ld-linux-aarch64.so.1 (0x0000ffff9c600000)
+"""
+
+LDD_SAMPLE_POISONED = """\
+\tlinux-vdso.so.1 (0x00007ffe2c5fe000)
+\tlibcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007f1)
+\tlibc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2)
+"""
+
+LDD_SAMPLE_NOT_DYNAMIC = "\tnot a dynamic executable\n"
+
+LDD_SAMPLE_STATICALLY_LINKED = "\tstatically linked\n"
+
+
+def test_parse_ldd_dynamic_amd64():
+    sonames, is_static = parse_ldd_sonames(LDD_SAMPLE_DYNAMIC)
+    assert is_static is False
+    # absolute loader path normalized to basename
+    assert "ld-linux-x86-64.so.2" in sonames
+    assert "linux-vdso.so.1" in sonames
+    assert "libc.so.6" in sonames
+    assert "libgcc_s.so.1" in sonames
+    assert all(_allowlist_matches(s) for s in sonames)
+
+
+def test_parse_ldd_dynamic_aarch64():
+    sonames, is_static = parse_ldd_sonames(LDD_SAMPLE_DYNAMIC_AARCH64)
+    assert is_static is False
+    assert "ld-linux-aarch64.so.1" in sonames
+    assert "linux-vdso.so.1" in sonames
+    assert "libc.so.6" in sonames
+    assert all(_allowlist_matches(s) for s in sonames)
+
+
+def test_parse_ldd_poisoned():
+    sonames, is_static = parse_ldd_sonames(LDD_SAMPLE_POISONED)
+    assert is_static is False
+    assert "libcrypto.so.3" in sonames
+    assert not _allowlist_matches("libcrypto.so.3")
+
+
+def test_parse_ldd_not_a_dynamic_executable():
+    sonames, is_static = parse_ldd_sonames(LDD_SAMPLE_NOT_DYNAMIC)
+    assert is_static is True
+    assert sonames == []
+
+
+def test_parse_ldd_statically_linked():
+    sonames, is_static = parse_ldd_sonames(LDD_SAMPLE_STATICALLY_LINKED)
+    assert is_static is True
+    assert sonames == []
+
+
+# ----------------------------------------------------------------------
+# include_docs_into_stage
+# ----------------------------------------------------------------------
+
+def _mkproj(tmp_path: Path, *files: str) -> Path:
+    """Create a fake project root with the named files (empty bodies)."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "alire.toml").write_text("", encoding="utf-8")
+    for name in files:
+        (project / name).write_text(f"# {name}\n", encoding="utf-8")
+    return project
+
+
+def test_include_docs_success(tmp_path):
+    project = _mkproj(tmp_path, "LICENSE", "README.md", "CHANGELOG.md")
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    rc = include_docs_into_stage(stage, project, ["LICENSE", "README.md", "CHANGELOG.md"])
+    assert rc == 0
+    assert (stage / "LICENSE").is_file()
+    assert (stage / "README.md").is_file()
+    assert (stage / "CHANGELOG.md").is_file()
+
+
+def test_include_docs_fails_on_missing(tmp_path):
+    project = _mkproj(tmp_path, "LICENSE", "README.md")  # missing CHANGELOG.md
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    rc = include_docs_into_stage(stage, project, ["LICENSE", "README.md", "CHANGELOG.md"])
+    assert rc == 10
+
+
+def test_include_docs_fails_on_all_missing(tmp_path):
+    project = _mkproj(tmp_path)
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    rc = include_docs_into_stage(stage, project, ["LICENSE", "README.md"])
+    assert rc == 10
+
+
+# ----------------------------------------------------------------------
+# Tarball + sha256 + manifest
+# ----------------------------------------------------------------------
+
+def _stage_release_layout(tmp_path: Path, basename: str,
+                          bin_name: str = "adafmt",
+                          docs: list = None,
+                          bundled_libs: list = None) -> Path:
+    """Create a fake staged release layout at tmp_path/dist/<basename>/."""
+    docs = docs or []
+    bundled_libs = bundled_libs or []
+    dist = tmp_path / "dist"
+    stage = dist / basename
+    (stage / "bin").mkdir(parents=True)
+    (stage / "bin" / bin_name).write_bytes(b"#!/bin/sh\necho fake-binary\n")
+    if bundled_libs:
+        (stage / "lib").mkdir()
+        for libname in bundled_libs:
+            (stage / "lib" / libname).write_bytes(b"\x7fELF")
+    for doc in docs:
+        (stage / doc).write_text(f"# {doc}\n", encoding="utf-8")
+    return dist
+
+
+def test_create_tarball_produces_top_level_dir(tmp_path):
+    basename = "adafmt-1.0.0-rc1-linux-amd64"
+    dist = _stage_release_layout(tmp_path, basename,
+                                 docs=["LICENSE", "README.md"])
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    tarball, rc = create_tarball(dist, basename, output_dir)
+    assert rc == 0
+    assert tarball.is_file()
+    assert tarball.name == f"{basename}.tar.gz"
+
+    # tar -tzf the produced archive and confirm exactly the expected top-level dir
+    cp = subprocess.run(["tar", "-tzf", str(tarball)],
+                        capture_output=True, text=True, check=True)
+    entries = [line for line in cp.stdout.splitlines() if line.strip()]
+    # Top-level directory must be present and be the single root.
+    assert f"{basename}/" in entries
+    roots = {e.split("/", 1)[0] for e in entries}
+    assert roots == {basename}, f"multiple roots: {roots}"
+
+
+def test_create_tarball_excludes_macos_metadata(tmp_path):
+    basename = "adafmt-1.0.0-rc1-linux-amd64"
+    dist = _stage_release_layout(tmp_path, basename, docs=["LICENSE"])
+    # Inject AppleDouble + .DS_Store files into the staged tree.
+    (dist / basename / "._LICENSE").write_bytes(b"AppleDouble-fork")
+    (dist / basename / "bin" / "._adafmt").write_bytes(b"AppleDouble-fork")
+    (dist / basename / ".DS_Store").write_bytes(b"DS_Store-data")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    tarball, rc = create_tarball(dist, basename, output_dir)
+    assert rc == 0
+
+    cp = subprocess.run(["tar", "-tzf", str(tarball)],
+                        capture_output=True, text=True, check=True)
+    listing = cp.stdout
+    assert "._LICENSE" not in listing
+    assert "._adafmt" not in listing
+    assert ".DS_Store" not in listing
+
+
+def test_write_sha256_matches_recomputed_digest(tmp_path):
+    basename = "adafmt-1.0.0-rc1-linux-amd64"
+    dist = _stage_release_layout(tmp_path, basename)
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    tarball, rc = create_tarball(dist, basename, output_dir)
+    assert rc == 0
+
+    sha_path, rc = write_sha256(tarball)
+    assert rc == 0
+    assert sha_path.exists()
+
+    line = sha_path.read_text(encoding="utf-8").strip()
+    parts = line.split()
+    assert len(parts) == 2, f"sha256 line malformed: {line!r}"
+    declared_hash, declared_name = parts[0], parts[1]
+    assert declared_name == tarball.name
+
+    h = hashlib.sha256()
+    h.update(tarball.read_bytes())
+    assert declared_hash == h.hexdigest()
+
+
+# ----------------------------------------------------------------------
+# expected_manifest_entries + verify_tarball_manifest
+# ----------------------------------------------------------------------
+
+def test_expected_manifest_entries_minimal():
+    expected = expected_manifest_entries(
+        basename="adafmt-1.0.0-rc1-linux-amd64",
+        bin_name="adafmt",
+        doc_list=[],
+        bundled_lib_names=[],
+    )
+    assert expected == {
+        "adafmt-1.0.0-rc1-linux-amd64/",
+        "adafmt-1.0.0-rc1-linux-amd64/bin/",
+        "adafmt-1.0.0-rc1-linux-amd64/bin/adafmt",
+    }
+
+
+def test_expected_manifest_entries_with_docs_and_libs():
+    expected = expected_manifest_entries(
+        basename="x-amd64",
+        bin_name="adafmt",
+        doc_list=["LICENSE", "README.md"],
+        bundled_lib_names=["libgnat-15.so", "libgnarl-15.so"],
+    )
+    assert "x-amd64/" in expected
+    assert "x-amd64/bin/adafmt" in expected
+    assert "x-amd64/lib/" in expected
+    assert "x-amd64/lib/libgnat-15.so" in expected
+    assert "x-amd64/lib/libgnarl-15.so" in expected
+    assert "x-amd64/LICENSE" in expected
+    assert "x-amd64/README.md" in expected
+
+
+def test_verify_tarball_manifest_accepts_allowed(tmp_path):
+    basename = "x-amd64"
+    dist = _stage_release_layout(tmp_path, basename,
+                                 docs=["LICENSE"])
+    out = tmp_path / "out"
+    out.mkdir()
+    tarball, _ = create_tarball(dist, basename, out)
+
+    expected = expected_manifest_entries(
+        basename=basename, bin_name="adafmt",
+        doc_list=["LICENSE"], bundled_lib_names=[],
+    )
+    listing, rc = verify_tarball_manifest(tarball, expected)
+    assert rc == 0
+    assert any(e.endswith("/bin/adafmt") for e in listing)
+
+
+def test_verify_tarball_manifest_rejects_unexpected_entry(tmp_path):
+    basename = "x-amd64"
+    dist = _stage_release_layout(tmp_path, basename,
+                                 docs=["LICENSE"])
+    # Inject an unexpected file into the staged tree before tarring.
+    (dist / basename / "OOPS_UNEXPECTED.txt").write_text("nope", encoding="utf-8")
+    out = tmp_path / "out"
+    out.mkdir()
+    tarball, _ = create_tarball(dist, basename, out)
+
+    expected = expected_manifest_entries(
+        basename=basename, bin_name="adafmt",
+        doc_list=["LICENSE"], bundled_lib_names=[],
+    )
+    _listing, rc = verify_tarball_manifest(tarball, expected)
+    assert rc == 12


### PR DESCRIPTION
## Summary

Adds release-packaging surface to `package_dist.py` for adafmt v1.0.0 RC-1 Linux distribution (adafmt#62).  Single-layout design — no legacy flat-dist mode preserved, since nothing has been released to the world yet.

This PR-A unblocks the follow-on PR-B in `adafmt`, which will bump the `scripts/python/shared` submodule pointer to this commit and add the `release-linux.yml` workflow + README "Install" section.

## New flags

### `--tarball <BASENAME>` (REQUIRED)

- Stages under `dist/<basename>/`, produces `<project>/<basename>.tar.gz` containing the single top-level `<basename>/` directory.
- Emits `<basename>.tar.gz.sha256` in `sha256sum`-compatible format.
- Verifies the produced tarball's contents against an allow-set (top dir, `bin/<exe>`, optional `lib/*` if libs were bundled, each `--include-docs` file).
- Streams the final `tar -tzf` listing to stdout for workflow-log manifest visibility.
- Excludes macOS AppleDouble (`._*`) and `.DS_Store` files; on Darwin hosts also runs `xattr -c -r` on the staged tree before tarring.

### `--include-docs <comma-separated paths>`

- Copies named project-root files into the staged tree.
- **Missing files fail (exit 10) with the resolved absolute path of each missing entry — no silent skipping.**  Release artifacts must not ship without required documentation.

### `--strict-system-deps`

- Linux only.  After bundling, verifies the binary's dynamic dependency closure matches `ALLOWED_SYSTEM_DEPS` — a narrow allowlist: \`libc\`, \`libm\`, \`libdl\`, \`libpthread\`, \`librt\`, \`libgcc_s\`, \`ld-linux*\`, \`linux-vdso\`.
- Prefers \`readelf -d\` for NEEDED parsing; falls back to \`ldd\` if \`readelf\` is unavailable or returns non-zero.
- Three explicit success paths: (a) dynamic binary with only allowlisted system deps, (b) statically-linked binary (\`ldd\` reports \`not a dynamic executable\` / \`statically linked\`), (c) parsed-as-empty NEEDED list.
- Fails (exit 9) on any disallowed entry, listing the disallowed sonames and the active allowlist.

## Exit codes (consolidated)

| Code | Meaning |
|---|---|
| 0 | success |
| 2 | missing \`alire.toml\` in \`--project-dir\` |
| 3 | \`alr build\` failed |
| 4 | \`--bin-name\` auto-detect ambiguous |
| 5 | binary not found in \`bin/\` |
| 6 | Linux \`ldd\` bundling still reports missing deps |
| 7 | unsupported platform |
| 8 | smoke test FAIL |
| 9 | \`--strict-system-deps\` allowlist violation |
| 10 | \`--include-docs\` missing a named file |
| 11 | tarball / sha256 step failed |
| 12 | manifest check found unexpected entry |

## Tests

\`tests/test_package_dist.py\` adds **39 new tests** covering:

- Allowlist: 10 accepted sonames + 10 rejected (\`libcrypto\`, \`libssl\`, \`libstdc++\`, \`libiconv\`, malformed forms, etc.) + count-is-locked sanity (forces deliberate review if the allowlist broadens).
- \`readelf -d\` parser: dynamic, poisoned, empty.
- \`ldd\` parser: dynamic amd64, dynamic aarch64, poisoned, "not a dynamic executable", "statically linked".  Verifies absolute-path loader entries normalize to basenames; verifies vDSO matches the allowlist.
- \`--include-docs\`: success path, missing-one-file fail, all-missing fail (all return exit 10).
- Tarball production: single top-level dir, exclusion of \`._*\` and \`.DS_Store\`, sha256 round-trip (recomputed in-test).
- Manifest verification: accept allowed contents, reject unexpected entries (exit 12).

Full suite result: **117 passing** (78 baseline + 39 new).  No regressions.

## Consumer impact

Checked current consumers under `~/Ada/github.com/abitofhelp/` (`functional`, `clara`, `hybrid_lib_ada`, `hybrid_app_ada`, `adafmt`, `astfmt`, `tzif`, `zoneinfo`).  No Makefile, workflow, or top-level script currently invokes `package_dist.py`, so the single-layout packaging behavior has no current caller breakage.  Future Go/C++ reference repos will adopt the new behavior directly.

## Out of scope

- \`release-linux.yml\` workflow (lands in adafmt PR-B against this).
- adafmt README "Install" section (lands in adafmt PR-B).
- macOS release packaging (post-v1.0.0 RC-1; macOS deferred per adafmt project memory).
- Windows release packaging (post-v1.0.0).

## Test plan

- [x] Syntax check: \`python3 -c "import ast; ast.parse(...)"\` clean
- [x] New tests: \`pytest tests/test_package_dist.py -v\` → 39 passing
- [x] Regression check: \`pytest tests/\` → 117 passing
- [ ] PR-B in adafmt will exercise the new flags end-to-end against the real adafmt build on Linux amd64 + arm64 GitHub-hosted runners

## Refs

- adafmt#62 — release distribution audit (the consumer of this script)
- adafmt#20 — Windows CI restoration (post-RC-1)
- adafmt#111 — entitlement service roadmap (post-RC-1; pre-GA)
