### PR TITLE
feat(release): add rc-tag subcommand for guarded draft prereleases

### DIFF
--- a/release/models.py
+++ b/release/models.py
@@ -43,6 +43,7 @@ class ReleaseAction(Enum):
     PREPARE = 'prepare'
     RELEASE = 'release'
     VALIDATE = 'validate'
+    RC_TAG = 'rc-tag'
 
 
 @dataclass

--- a/release/release.py
+++ b/release/release.py
@@ -881,6 +881,390 @@ def create_release(config, adapter) -> bool:
     return True
 
 
+def _run_capture(cmd, cwd):
+    """Run a command capturing stdout/stderr. Never raises."""
+    return subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, errors='replace'
+    )
+
+
+def create_rc_release(config, adapter, args) -> bool:
+    """Create a release candidate as DRAFT + PRERELEASE with an explicit
+    annotated tag pointing at a specific commit SHA.
+
+    Every gh/git boundary operation is followed by an explicit post-state
+    verification step — silent return is never inferred as success
+    (see feedback_no_silent_success_inference_at_boundaries).
+
+    Ordered steps (each individually verified):
+      1. Preflight: clean tree, fresh fetch, local main == origin/main,
+         target SHA resolves to a commit, target is ancestor of origin/main,
+         local tag absent, remote tag absent, GitHub Release absent,
+         release-notes file present + non-empty.
+      2. gh release create --draft --prerelease --target <SHA>.
+      3. Verify Release isDraft + isPrerelease + tagName + targetCommitish.
+      4. git tag -a <tag> <SHA> -m <message>.
+      5. Verify local tag points at expected SHA.
+      6. git push origin <tag>  (tag only — never main).
+      7. Verify remote tag commit SHA matches local.
+      8. Locate release-linux.yml run dispatched by the tag push.
+      9. Print summary + manual next steps (publish via gh release edit).
+
+    --dry-run still runs all read-only preflight verifications but skips
+    every mutation (gh release create, git tag, git push).
+
+    Args:
+        config:  ReleaseConfig (project_root, version, dry_run).
+        adapter: Language adapter (only used for verify_clean_working_tree).
+        args:    argparse.Namespace carrying target, tag_message,
+                 release_title, release_notes_file.
+
+    Returns:
+        True on success, False on any failure.
+    """
+    tag_name = config.tag_name  # "v<version>"
+    target_sha = args.target
+    tag_message = args.tag_message or f"Release candidate {config.version}"
+    release_title = args.release_title or f"Release {config.version}"
+    dry = bool(config.dry_run)
+
+    print_section(f"\n{'='*70}")
+    print_section(
+        f"RC-TAG {tag_name} -> {target_sha[:12]} (DRAFT, PRERELEASE)"
+        + (" [DRY-RUN]" if dry else "")
+    )
+    print_section(f"{'='*70}\n")
+
+    # --- Step 1: PREFLIGHT (always runs, even in dry-run) ---
+    print_section("Step 1/9: Preflight")
+
+    # 1a. Working tree clean
+    print_info("  1a. Verifying clean working tree...")
+    if not adapter.verify_clean_working_tree(config):
+        print_error("  Working tree is not clean.")
+        return False
+    print_success("  Working tree is clean")
+
+    # 1b. Fetch origin (refs + tags); read-only relative to working tree
+    print_info("  1b. Fetching origin (refs + tags)...")
+    r = _run_capture(["git", "fetch", "origin", "--tags"], config.project_root)
+    if r.returncode != 0:
+        print_error(f"  git fetch failed: {r.stderr.strip()}")
+        return False
+    print_success("  Fetched origin")
+
+    # 1c. local main == origin/main
+    print_info("  1c. Verifying local main == origin/main...")
+    r_local = _run_capture(["git", "rev-parse", "main"], config.project_root)
+    r_remote = _run_capture(["git", "rev-parse", "origin/main"], config.project_root)
+    if r_local.returncode != 0 or r_remote.returncode != 0:
+        print_error("  Could not resolve main / origin/main SHAs.")
+        return False
+    local_main = r_local.stdout.strip()
+    remote_main = r_remote.stdout.strip()
+    if local_main != remote_main:
+        print_error(
+            f"  Local main {local_main} != origin/main {remote_main}. "
+            "Fast-forward local main first."
+        )
+        return False
+    print_success(f"  main == origin/main == {local_main[:12]}")
+
+    # 1d. Target SHA resolves to a commit
+    print_info(f"  1d. Verifying target SHA {target_sha[:12]} resolves...")
+    r = _run_capture(
+        ["git", "rev-parse", "--verify", f"{target_sha}^{{commit}}"],
+        config.project_root,
+    )
+    if r.returncode != 0:
+        print_error(f"  Target SHA does not resolve to a commit: {target_sha}")
+        return False
+    resolved_target = r.stdout.strip()
+    print_success(f"  Target resolves to {resolved_target}")
+
+    # 1e. Target is an ancestor of (or equal to) origin/main
+    print_info("  1e. Verifying target is ancestor of origin/main...")
+    r = _run_capture(
+        ["git", "merge-base", "--is-ancestor", resolved_target, remote_main],
+        config.project_root,
+    )
+    if r.returncode != 0:
+        print_error(
+            f"  Target {resolved_target[:12]} is NOT an ancestor of "
+            f"origin/main {remote_main[:12]}."
+        )
+        return False
+    print_success("  Target is ancestor of origin/main")
+
+    # 1f. Local tag absent
+    print_info(f"  1f. Verifying local tag {tag_name} absent...")
+    r = _run_capture(["git", "tag", "-l", tag_name], config.project_root)
+    if r.stdout.strip() == tag_name:
+        print_error(f"  Local tag {tag_name} already exists.")
+        return False
+    print_success(f"  Local tag {tag_name} absent")
+
+    # 1g. Remote tag absent
+    print_info(f"  1g. Verifying remote tag {tag_name} absent...")
+    r = _run_capture(
+        ["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag_name}"],
+        config.project_root,
+    )
+    if r.stdout.strip() != "":
+        print_error(
+            f"  Remote tag {tag_name} already exists:\n  {r.stdout.strip()}"
+        )
+        return False
+    print_success(f"  Remote tag {tag_name} absent")
+
+    # 1h. GitHub Release absent
+    print_info(f"  1h. Verifying GitHub Release {tag_name} absent...")
+    r = _run_capture(
+        ["gh", "release", "view", tag_name], config.project_root
+    )
+    if r.returncode == 0:
+        print_error(f"  GitHub Release {tag_name} already exists.")
+        return False
+    print_success(f"  GitHub Release {tag_name} absent")
+
+    # 1i. Release-notes file present + non-empty
+    notes_path = Path(args.release_notes_file).expanduser()
+    if not notes_path.is_absolute():
+        notes_path = (config.project_root / notes_path).resolve()
+    print_info(f"  1i. Verifying release-notes file: {notes_path}")
+    if not notes_path.is_file():
+        print_error(f"  Release-notes file not found: {notes_path}")
+        return False
+    if notes_path.stat().st_size == 0:
+        print_error(f"  Release-notes file is empty: {notes_path}")
+        return False
+    print_success(
+        f"  Release-notes file present ({notes_path.stat().st_size} bytes)"
+    )
+
+    # --- Step 2: Create DRAFT + PRERELEASE Release ---
+    print_section("\nStep 2/9: Create GitHub Release (draft, prerelease)")
+    create_cmd = [
+        "gh", "release", "create", tag_name,
+        "--draft",
+        "--prerelease",
+        "--target", resolved_target,
+        "--title", release_title,
+        "--notes-file", str(notes_path),
+    ]
+    if dry:
+        print_info(f"  [DRY-RUN] Would run: {' '.join(create_cmd)}")
+    else:
+        r = _run_capture(create_cmd, config.project_root)
+        if r.returncode != 0:
+            print_error(
+                f"  gh release create failed (rc={r.returncode}): "
+                f"{r.stderr.strip()}"
+            )
+            return False
+        print_success(
+            f"  Created draft prerelease: {r.stdout.strip() or tag_name}"
+        )
+
+    # --- Step 3: Verify Release state via re-query ---
+    print_section("\nStep 3/9: Verify Release state")
+    if dry:
+        print_info(
+            "  [DRY-RUN] Would verify isDraft=true, isPrerelease=true, "
+            f"tagName={tag_name}, targetCommitish={resolved_target[:12]}"
+        )
+    else:
+        r = _run_capture(
+            ["gh", "release", "view", tag_name,
+             "--json", "isDraft,isPrerelease,targetCommitish,tagName"],
+            config.project_root,
+        )
+        if r.returncode != 0:
+            print_error(f"  gh release view failed: {r.stderr.strip()}")
+            return False
+        try:
+            data = json.loads(r.stdout)
+        except json.JSONDecodeError as e:
+            print_error(f"  Could not parse gh release view JSON: {e}")
+            return False
+        if not data.get("isDraft"):
+            print_error(f"  Release is not draft: {data}")
+            return False
+        if not data.get("isPrerelease"):
+            print_error(f"  Release is not prerelease: {data}")
+            return False
+        if data.get("tagName") != tag_name:
+            print_error(
+                f"  Tag name mismatch: {data.get('tagName')} != {tag_name}"
+            )
+            return False
+        if data.get("targetCommitish") != resolved_target:
+            print_error(
+                "  Target commitish mismatch: "
+                f"{data.get('targetCommitish')} != {resolved_target}"
+            )
+            return False
+        print_success(
+            f"  Release verified: draft + prerelease, target={resolved_target[:12]}"
+        )
+
+    # --- Step 4: Create annotated tag locally at target SHA ---
+    print_section("\nStep 4/9: Create annotated tag locally")
+    tag_cmd = [
+        "git", "tag", "-a", tag_name, resolved_target, "-m", tag_message,
+    ]
+    if dry:
+        print_info(f"  [DRY-RUN] Would run: {' '.join(tag_cmd)}")
+    else:
+        r = _run_capture(tag_cmd, config.project_root)
+        if r.returncode != 0:
+            print_error(f"  git tag failed: {r.stderr.strip()}")
+            return False
+        print_success(f"  Created local annotated tag {tag_name}")
+
+    # --- Step 5: Verify local tag commit SHA ---
+    print_section("\nStep 5/9: Verify local tag SHA")
+    if dry:
+        print_info(
+            f"  [DRY-RUN] Would verify {tag_name}^{{commit}} == "
+            f"{resolved_target[:12]}"
+        )
+    else:
+        r = _run_capture(
+            ["git", "rev-list", "-n", "1", tag_name], config.project_root
+        )
+        if r.returncode != 0:
+            print_error(f"  git rev-list failed: {r.stderr.strip()}")
+            return False
+        tagged_commit = r.stdout.strip()
+        if tagged_commit != resolved_target:
+            print_error(
+                f"  Tag commit {tagged_commit} != expected {resolved_target}"
+            )
+            return False
+        print_success(f"  Local tag {tag_name} -> {tagged_commit}")
+
+    # --- Step 6: Push tag only (NOT main) ---
+    print_section("\nStep 6/9: Push tag to origin (tag only)")
+    push_cmd = ["git", "push", "origin", tag_name]
+    if dry:
+        print_info(f"  [DRY-RUN] Would run: {' '.join(push_cmd)}")
+    else:
+        r = _run_capture(push_cmd, config.project_root)
+        if r.returncode != 0:
+            print_error(f"  git push failed: {r.stderr.strip()}")
+            return False
+        print_success(f"  Pushed tag {tag_name}")
+
+    # --- Step 7: Verify remote tag commit matches local ---
+    print_section("\nStep 7/9: Verify remote tag")
+    if dry:
+        print_info(
+            f"  [DRY-RUN] Would verify origin {tag_name} -> "
+            f"{resolved_target[:12]}"
+        )
+    else:
+        r = _run_capture(
+            ["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag_name}"],
+            config.project_root,
+        )
+        if r.returncode != 0 or r.stdout.strip() == "":
+            print_error(
+                f"  Remote tag {tag_name} not visible after push:\n"
+                f"  stdout={r.stdout!r} stderr={r.stderr.strip()!r}"
+            )
+            return False
+        # ls-remote prints <obj-sha>\t<ref>; for annotated tags it also
+        # prints a peeled "<commit-sha>\trefs/tags/<tag>^{}" entry — that's
+        # the commit we want to compare against resolved_target.
+        peeled = None
+        for line in r.stdout.strip().splitlines():
+            parts = line.split(None, 1)
+            if len(parts) != 2:
+                continue
+            sha, ref = parts[0], parts[1].strip()
+            if ref == f"refs/tags/{tag_name}^{{}}":
+                peeled = sha
+                break
+        if peeled is None:
+            # No peeled ref (lightweight tag, unexpected here): take the
+            # single ref line as the commit.
+            first = r.stdout.strip().splitlines()[0].split(None, 1)
+            peeled = first[0] if first else ""
+        if peeled != resolved_target:
+            print_error(
+                f"  Remote tag commit {peeled} != expected {resolved_target}"
+            )
+            return False
+        print_success(f"  Remote tag {tag_name} -> {peeled}")
+
+    # --- Step 8: Locate the new release-linux.yml run ---
+    print_section("\nStep 8/9: Locate release-linux workflow run")
+    new_run = None
+    if dry:
+        print_info(
+            "  [DRY-RUN] Would query gh run list "
+            "--workflow=release-linux.yml --json …"
+        )
+    else:
+        for attempt in range(6):  # up to ~30s
+            r = _run_capture(
+                ["gh", "run", "list",
+                 "--workflow=release-linux.yml",
+                 "--limit", "10",
+                 "--json", "databaseId,event,headBranch,status,createdAt,url"],
+                config.project_root,
+            )
+            if r.returncode == 0:
+                try:
+                    runs = json.loads(r.stdout)
+                except json.JSONDecodeError:
+                    runs = []
+                for run in runs:
+                    # Tag-triggered workflows: gh sets headBranch to the tag.
+                    if run.get("headBranch") == tag_name:
+                        new_run = run
+                        break
+            if new_run is not None:
+                break
+            time.sleep(5)
+        if new_run is None:
+            print_warning(
+                f"  Did not locate release-linux run for {tag_name} within "
+                "30s. The workflow may still be queueing; check the Actions "
+                "tab manually."
+            )
+        else:
+            print_success(
+                f"  Found run {new_run['databaseId']} "
+                f"(status={new_run.get('status', 'unknown')})"
+            )
+
+    # --- Step 9: Summary + manual next steps ---
+    print_section("\nStep 9/9: Summary")
+    print_section(f"\n{'='*70}")
+    print_success(
+        f"RC-TAG {tag_name} COMPLETE (draft + prerelease)"
+        + (" [DRY-RUN]" if dry else "")
+    )
+    print_section(f"{'='*70}")
+    print_info(f"Tag      : {tag_name} -> {resolved_target}")
+    if config.project_url:
+        print_info(
+            f"Release  : {config.project_url}/releases/tag/{tag_name}"
+        )
+    if not dry and new_run is not None:
+        url = new_run.get('url') or f"(run id {new_run['databaseId']})"
+        print_info(f"CI run   : {url}")
+        print_info(f"CI state : {new_run.get('status', 'unknown')}")
+    print_info("")
+    print_info("NEXT STEPS (manual, after CI passes and artifacts uploaded):")
+    print_info(f"  1. Smoke-test the release-linux.yml artifacts.")
+    print_info(f"  2. Publish: gh release edit {tag_name} --draft=false")
+    print()
+    return True
+
+
 def main():
     """Main entry point."""
     parser = argparse.ArgumentParser(
@@ -893,6 +1277,10 @@ Examples:
   %(prog)s prepare 1.0.0 --skip=windows,spark
                                         Skip multiple stages
   %(prog)s release 1.0.0                Create release (tag, push, GitHub)
+  %(prog)s rc-tag 1.0.0-rc3 --target <SHA> \\
+        --release-notes-file docs/release_notes/v1.0.0_draft.md
+                                        Tag an RC at an explicit SHA as a
+                                        draft, prerelease GitHub Release.
 
 Skippable stages: windows, spark, exceptions, all
 
@@ -903,7 +1291,7 @@ the appropriate release workflow.
 
     parser.add_argument(
         'action',
-        choices=['prepare', 'release', 'validate'],
+        choices=['prepare', 'release', 'validate', 'rc-tag'],
         help='Action to perform'
     )
 
@@ -942,6 +1330,39 @@ the appropriate release workflow.
         help=f'Skip specific stages (comma-separated). Available: {stage_list}, all'
     )
 
+    # rc-tag-specific arguments (ignored by other actions)
+    parser.add_argument(
+        '--target',
+        type=str,
+        default=None,
+        metavar='SHA',
+        help='[rc-tag] Explicit commit SHA to tag (must be ancestor of '
+             'origin/main).'
+    )
+    parser.add_argument(
+        '--tag-message',
+        type=str,
+        default=None,
+        metavar='MSG',
+        help='[rc-tag] Annotated-tag message (default: '
+             '"Release candidate <version>").'
+    )
+    parser.add_argument(
+        '--release-title',
+        type=str,
+        default=None,
+        metavar='TITLE',
+        help='[rc-tag] GitHub Release title (default: "Release <version>").'
+    )
+    parser.add_argument(
+        '--release-notes-file',
+        type=str,
+        default=None,
+        metavar='PATH',
+        help='[rc-tag] Path to release-notes markdown file. Relative paths '
+             'resolve from --project-root.'
+    )
+
     args = parser.parse_args()
 
     # Parse --skip into a set of stages
@@ -959,8 +1380,8 @@ the appropriate release workflow.
     else:
         args.skip_stages = set()
 
-    # Validate version is provided for prepare/release
-    if args.action in ['prepare', 'release', 'validate'] and not args.version:
+    # Validate version is provided for prepare/release/rc-tag
+    if args.action in ['prepare', 'release', 'validate', 'rc-tag'] and not args.version:
         print_error(f"Version is required for {args.action} action")
         parser.print_help()
         return 1
@@ -972,6 +1393,24 @@ the appropriate release workflow.
     ):
         print_error("Version must follow semantic versioning (e.g., 1.0.0, 1.0.0-dev)")
         return 1
+
+    # rc-tag-specific argument validation
+    if args.action == 'rc-tag':
+        missing = []
+        if not args.target:
+            missing.append('--target')
+        if not args.release_notes_file:
+            missing.append('--release-notes-file')
+        if missing:
+            print_error(
+                f"rc-tag action requires: {', '.join(missing)}"
+            )
+            return 1
+        if not re.match(r'^[0-9a-fA-F]{7,40}$', args.target):
+            print_error(
+                f"--target must be a 7-40 char hex SHA, got: {args.target!r}"
+            )
+            return 1
 
     # Determine project root
     if args.project_root:
@@ -1026,6 +1465,8 @@ the appropriate release workflow.
             success = prepare_release(config, adapter)
         elif args.action == 'release':
             success = create_release(config, adapter)
+        elif args.action == 'rc-tag':
+            success = create_rc_release(config, adapter, args)
         elif args.action == 'validate':
             # Future: add validation-only mode
             print_info("Validate action not yet implemented")

--- a/release/release.py
+++ b/release/release.py
@@ -1000,7 +1000,9 @@ def create_rc_release(config, adapter, args) -> bool:
       3. Verify local tag:
          - object type is "tag" (annotated, not lightweight)
          - peels to target SHA
-         - subject matches expected message
+         - FULL annotated tag message matches the expected message
+           (only trailing newlines are normalized; internal structure
+           and body content are compared verbatim)
       4. Capture before_push UTC timestamp; git push origin refs/tags/<tag>
          (tag only — never main)
       5. Verify remote tag peels to target SHA
@@ -1281,10 +1283,13 @@ def create_rc_release(config, adapter, args) -> bool:
     print_section("\nStep 3/9: Verify local tag is annotated + correct")
     local_tag_obj_sha = "(unknown)"
     if dry:
+        _exp_msg_norm = tag_message.rstrip('\n')
+        _exp_subject = _exp_msg_norm.split('\n', 1)[0]
         print_info(
             f"  [DRY-RUN] Would verify {tag_name}: object type=tag, "
-            f"peels to {resolved_target[:12]}, subject matches "
-            f"{tag_message.split(chr(10), 1)[0]!r}"
+            f"peels to {resolved_target[:12]}, full annotated message "
+            f"matches expected ({len(_exp_msg_norm)} chars, "
+            f"subject={_exp_subject!r})"
         )
     else:
         # 3a. Object type must be "tag" (annotated, not lightweight).
@@ -1323,27 +1328,49 @@ def create_rc_release(config, adapter, args) -> bool:
             _emit_remediation_local_tag_only(tag_name)
             return False
 
-        # 3c. Tag subject matches first line of expected message.
+        # 3c. FULL annotated tag message matches expected.
+        # `git for-each-ref --format=%(contents)` on an annotated tag ref
+        # returns the entire tag message (subject + blank line + body, if
+        # any), excluding the header lines (object/type/tag/tagger).
+        #
+        # Newline normalization: only trailing '\n' characters are stripped
+        # from both sides; internal whitespace, blank lines, and body
+        # structure are compared verbatim. A multi-line message is therefore
+        # verified in full, not only by its subject line.
         r = _run_capture(
-            ["git", "tag", "-l", "--format=%(contents:subject)", tag_name],
+            ["git", "for-each-ref",
+             "--format=%(contents)",
+             f"refs/tags/{tag_name}"],
             config.project_root,
         )
         if r.returncode != 0:
             print_error(
-                f"  git tag -l --format failed: {r.stderr.strip()}"
+                f"  git for-each-ref --format failed: {r.stderr.strip()}"
             )
             _emit_remediation_local_tag_only(tag_name)
             return False
-        actual_subject = r.stdout.strip()
-        expected_subject = tag_message.split('\n', 1)[0].strip()
-        if actual_subject != expected_subject:
+        # An empty stdout here would indicate the ref didn't resolve to an
+        # annotated tag (or didn't resolve at all); treat as fail.
+        if r.stdout == "":
             print_error(
-                "  Tag subject mismatch.\n"
-                f"  Expected: {expected_subject!r}\n"
-                f"  Actual  : {actual_subject!r}"
+                f"  git for-each-ref returned empty output for "
+                f"refs/tags/{tag_name}; cannot verify tag message."
             )
             _emit_remediation_local_tag_only(tag_name)
             return False
+        actual_message = r.stdout.rstrip('\n')
+        expected_message = tag_message.rstrip('\n')
+        if actual_message != expected_message:
+            print_error(
+                "  Annotated tag message mismatch (full-message compare).\n"
+                f"  Expected ({len(expected_message)} chars): "
+                f"{expected_message!r}\n"
+                f"  Actual   ({len(actual_message)} chars): "
+                f"{actual_message!r}"
+            )
+            _emit_remediation_local_tag_only(tag_name)
+            return False
+        actual_subject = actual_message.split('\n', 1)[0]
 
         # 3d. Capture tag object SHA for reporting.
         r = _run_capture(
@@ -1354,7 +1381,9 @@ def create_rc_release(config, adapter, args) -> bool:
 
         print_success(
             f"  Annotated tag {tag_name} OK (obj={local_tag_obj_sha[:12]}, "
-            f"commit={tagged_commit[:12]}, subject={actual_subject!r})"
+            f"commit={tagged_commit[:12]}, "
+            f"msg={len(actual_message)} chars, "
+            f"subject={actual_subject!r})"
         )
 
     # =====================================================================

--- a/release/release.py
+++ b/release/release.py
@@ -32,7 +32,7 @@ import re
 import subprocess
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -888,30 +888,141 @@ def _run_capture(cmd, cwd):
     )
 
 
+# ---------------------------------------------------------------------------
+# Partial-state remediation messages for rc-tag.
+#
+# Each helper is called on a hard failure that occurs after one or more
+# mutations succeeded, so the user always knows what state to clean up.
+# ---------------------------------------------------------------------------
+
+def _emit_remediation_local_tag_only(tag_name):
+    print_warning(
+        "\n  PARTIAL STATE: a local annotated tag was created but no remote "
+        "action completed.\n"
+        f"  Local tag present     : {tag_name}\n"
+        "  Remote tag present    : NO\n"
+        "  GitHub Release present: NO\n"
+        "  release-linux.yml run : NOT DISPATCHED\n"
+        "  Roll back the local-only tag:\n"
+        f"    git tag -d {tag_name}\n"
+    )
+
+
+def _emit_remediation_remote_tag_only(tag_name):
+    print_warning(
+        "\n  PARTIAL STATE: the annotated tag was pushed to origin but the "
+        "GitHub Release was not created.\n"
+        f"  Local tag present     : {tag_name}\n"
+        f"  Remote tag present    : {tag_name}\n"
+        "  GitHub Release present: NO\n"
+        "  release-linux.yml run : MAY HAVE DISPATCHED (tag push triggers it)\n"
+        "  Choices:\n"
+        "    (a) Retry Release creation (tag is already in place):\n"
+        f"        gh release create {tag_name} --draft --prerelease "
+        "--verify-tag \\\n"
+        "          --title <TITLE> --notes-file <PATH>\n"
+        "    (b) Roll back the tag (cancels release-linux.yml if still "
+        "running):\n"
+        f"        git push origin :refs/tags/{tag_name}\n"
+        f"        git tag -d {tag_name}\n"
+    )
+
+
+def _emit_remediation_release_created(tag_name):
+    print_warning(
+        "\n  PARTIAL STATE: the tag and a draft Release exist; verification "
+        "of the Release failed.\n"
+        f"  Local tag present     : {tag_name}\n"
+        f"  Remote tag present    : {tag_name}\n"
+        f"  GitHub Release present: {tag_name} (state unverified)\n"
+        "  release-linux.yml run : likely dispatched\n"
+        "  Inspect:\n"
+        f"    gh release view {tag_name} --json "
+        "isDraft,isPrerelease,tagName,targetCommitish\n"
+        "    gh run list --workflow=release-linux.yml --event=push --limit 5\n"
+        "  Roll back (if needed):\n"
+        f"    gh release delete {tag_name} --yes\n"
+        f"    git push origin :refs/tags/{tag_name}\n"
+        f"    git tag -d {tag_name}\n"
+    )
+
+
+def _emit_remediation_workflow_missing(tag_name):
+    print_warning(
+        "\n  PARTIAL STATE: tag and draft Release exist, but no matching "
+        "release-linux.yml run was detected.\n"
+        f"  Local tag present     : {tag_name}\n"
+        f"  Remote tag present    : {tag_name}\n"
+        f"  GitHub Release present: {tag_name} (draft, prerelease)\n"
+        "  release-linux.yml run : NOT DETECTED\n"
+        "  Inspect:\n"
+        "    gh workflow view release-linux.yml\n"
+        "    gh run list --workflow=release-linux.yml --limit 10\n"
+        "  Possible causes:\n"
+        f"    - on:push:tags filter in the workflow file does not match "
+        f"{tag_name}\n"
+        "    - repository Actions are disabled\n"
+        "    - GitHub Actions outage\n"
+        "  Manual dispatch (if the workflow supports workflow_dispatch):\n"
+        f"    gh workflow run release-linux.yml --ref {tag_name}\n"
+        "  Roll back (if needed):\n"
+        f"    gh release delete {tag_name} --yes\n"
+        f"    git push origin :refs/tags/{tag_name}\n"
+        f"    git tag -d {tag_name}\n"
+    )
+
+
 def create_rc_release(config, adapter, args) -> bool:
-    """Create a release candidate as DRAFT + PRERELEASE with an explicit
-    annotated tag pointing at a specific commit SHA.
+    """Create a release candidate as a DRAFT + PRERELEASE GitHub Release
+    backed by an explicit annotated tag at a caller-supplied commit SHA.
+
+    SAFETY ORDERING (post-Codex review of PR #16):
+      The annotated tag is created and pushed BEFORE the GitHub Release is
+      created, and the Release is created with --verify-tag. This prevents
+      `gh release create` from auto-creating a remote tag of its own
+      (which could be lightweight or otherwise unintended).
 
     Every gh/git boundary operation is followed by an explicit post-state
-    verification step — silent return is never inferred as success
+    verification step. Silent return is never inferred as success
     (see feedback_no_silent_success_inference_at_boundaries).
 
-    Ordered steps (each individually verified):
-      1. Preflight: clean tree, fresh fetch, local main == origin/main,
-         target SHA resolves to a commit, target is ancestor of origin/main,
-         local tag absent, remote tag absent, GitHub Release absent,
-         release-notes file present + non-empty.
-      2. gh release create --draft --prerelease --target <SHA>.
-      3. Verify Release isDraft + isPrerelease + tagName + targetCommitish.
-      4. git tag -a <tag> <SHA> -m <message>.
-      5. Verify local tag points at expected SHA.
-      6. git push origin <tag>  (tag only — never main).
-      7. Verify remote tag commit SHA matches local.
-      8. Locate release-linux.yml run dispatched by the tag push.
-      9. Print summary + manual next steps (publish via gh release edit).
+    Ordered steps:
+      1. Preflight (read-only, fail-closed):
+         - clean working tree
+         - HEAD == main == origin/main == target (single canonical state;
+           caller may not tag anything other than the current main HEAD)
+         - local tag absent
+         - remote tag absent (distinguish not-found from query-failure)
+         - GitHub Release absent (distinguish not-found from query-failure)
+         - release-notes file present, non-empty, and byte-identical to
+           its committed content at the target SHA
+      2. git tag -a <tag> <SHA> -m <message>
+      3. Verify local tag:
+         - object type is "tag" (annotated, not lightweight)
+         - peels to target SHA
+         - subject matches expected message
+      4. Capture before_push UTC timestamp; git push origin refs/tags/<tag>
+         (tag only — never main)
+      5. Verify remote tag peels to target SHA
+      6. gh release create <tag> --draft --prerelease --verify-tag
+         (refuses to create if tag absent; never auto-creates a tag)
+      7. Verify Release: isDraft + isPrerelease + tagName
+      8. Confirm release-linux.yml dispatched a matching run.
+         Filter: workflow=release-linux.yml AND event=push AND
+                 createdAt >= before_push_iso - 30s AND
+                 (headBranch == <tag> OR headSha == <target>)
+         Hard failure if no matching run is found within ~40 s.
+      9. Summary + manual publish step (gh release edit <tag> --draft=false).
 
-    --dry-run still runs all read-only preflight verifications but skips
-    every mutation (gh release create, git tag, git push).
+    --dry-run is strictly non-mutating: every mutation step (including
+    `git fetch`, `git tag`, `git push`, `gh release create`) is skipped.
+    Read-only preflight verifications still run; they use whatever cached
+    remote-tracking refs already exist (caller should `git fetch` first
+    if fresh state is required).
+
+    On hard failure at any step *after* a mutation has succeeded, a
+    PARTIAL-STATE remediation block is printed naming exactly what
+    survived and how to roll it back or recover.
 
     Args:
         config:  ReleaseConfig (project_root, version, dry_run).
@@ -935,7 +1046,9 @@ def create_rc_release(config, adapter, args) -> bool:
     )
     print_section(f"{'='*70}\n")
 
-    # --- Step 1: PREFLIGHT (always runs, even in dry-run) ---
+    # =====================================================================
+    # Step 1: PREFLIGHT (read-only; runs in dry-run too; fail-closed)
+    # =====================================================================
     print_section("Step 1/9: Preflight")
 
     # 1a. Working tree clean
@@ -945,219 +1058,335 @@ def create_rc_release(config, adapter, args) -> bool:
         return False
     print_success("  Working tree is clean")
 
-    # 1b. Fetch origin (refs + tags); read-only relative to working tree
-    print_info("  1b. Fetching origin (refs + tags)...")
-    r = _run_capture(["git", "fetch", "origin", "--tags"], config.project_root)
-    if r.returncode != 0:
-        print_error(f"  git fetch failed: {r.stderr.strip()}")
-        return False
-    print_success("  Fetched origin")
+    # 1b. Fetch origin (refs + tags). NOT a no-op — it writes to
+    # .git/refs/remotes/origin/. Codex review: skip in dry-run.
+    if dry:
+        print_info(
+            "  1b. [DRY-RUN] Skipping `git fetch origin --tags` "
+            "(would mutate refs/remotes/origin/*).\n"
+            "      Using cached remote-tracking refs. Run "
+            "`git fetch origin --tags` before --dry-run if fresh state "
+            "is required."
+        )
+    else:
+        print_info("  1b. Fetching origin (refs + tags)...")
+        r = _run_capture(
+            ["git", "fetch", "origin", "--tags"], config.project_root
+        )
+        if r.returncode != 0:
+            print_error(f"  git fetch failed: {r.stderr.strip()}")
+            return False
+        print_success("  Fetched origin")
 
-    # 1c. local main == origin/main
-    print_info("  1c. Verifying local main == origin/main...")
-    r_local = _run_capture(["git", "rev-parse", "main"], config.project_root)
-    r_remote = _run_capture(["git", "rev-parse", "origin/main"], config.project_root)
-    if r_local.returncode != 0 or r_remote.returncode != 0:
-        print_error("  Could not resolve main / origin/main SHAs.")
-        return False
-    local_main = r_local.stdout.strip()
-    remote_main = r_remote.stdout.strip()
-    if local_main != remote_main:
+    # 1c. HEAD == main == origin/main == target (single canonical state).
+    print_info(
+        "  1c. Verifying HEAD == main == origin/main == target..."
+    )
+    head_r = _run_capture(
+        ["git", "rev-parse", "HEAD"], config.project_root
+    )
+    main_r = _run_capture(
+        ["git", "rev-parse", "main"], config.project_root
+    )
+    remote_r = _run_capture(
+        ["git", "rev-parse", "origin/main"], config.project_root
+    )
+    if (head_r.returncode != 0 or main_r.returncode != 0
+            or remote_r.returncode != 0):
         print_error(
-            f"  Local main {local_main} != origin/main {remote_main}. "
-            "Fast-forward local main first."
+            "  Query failed: cannot resolve one of HEAD/main/origin/main.\n"
+            f"  HEAD       : rc={head_r.returncode} {head_r.stderr.strip()!r}\n"
+            f"  main       : rc={main_r.returncode} {main_r.stderr.strip()!r}\n"
+            f"  origin/main: rc={remote_r.returncode} {remote_r.stderr.strip()!r}"
         )
         return False
-    print_success(f"  main == origin/main == {local_main[:12]}")
+    head_sha = head_r.stdout.strip()
+    main_sha = main_r.stdout.strip()
+    remote_main_sha = remote_r.stdout.strip()
 
-    # 1d. Target SHA resolves to a commit
-    print_info(f"  1d. Verifying target SHA {target_sha[:12]} resolves...")
+    # Resolve target SHA to a full canonical commit SHA.
     r = _run_capture(
         ["git", "rev-parse", "--verify", f"{target_sha}^{{commit}}"],
         config.project_root,
     )
     if r.returncode != 0:
-        print_error(f"  Target SHA does not resolve to a commit: {target_sha}")
+        print_error(
+            f"  Target SHA does not resolve to a commit: {target_sha} "
+            f"({r.stderr.strip()})"
+        )
         return False
     resolved_target = r.stdout.strip()
-    print_success(f"  Target resolves to {resolved_target}")
 
-    # 1e. Target is an ancestor of (or equal to) origin/main
-    print_info("  1e. Verifying target is ancestor of origin/main...")
+    if not (head_sha == main_sha == remote_main_sha == resolved_target):
+        print_error(
+            "  Required canonical state not satisfied:\n"
+            f"    HEAD        = {head_sha}\n"
+            f"    main        = {main_sha}\n"
+            f"    origin/main = {remote_main_sha}\n"
+            f"    target      = {resolved_target}\n"
+            "  All four must be equal. To recover, either:\n"
+            "    - check out main + fast-forward to origin/main, OR\n"
+            "    - re-invoke rc-tag with --target equal to current "
+            "origin/main HEAD."
+        )
+        return False
+    print_success(
+        f"  HEAD == main == origin/main == target == {resolved_target[:12]}"
+    )
+
+    # 1d. Local tag absent (fail-closed on query failure).
+    print_info(f"  1d. Verifying local tag {tag_name} absent...")
     r = _run_capture(
-        ["git", "merge-base", "--is-ancestor", resolved_target, remote_main],
-        config.project_root,
+        ["git", "tag", "-l", tag_name], config.project_root
     )
     if r.returncode != 0:
         print_error(
-            f"  Target {resolved_target[:12]} is NOT an ancestor of "
-            f"origin/main {remote_main[:12]}."
+            f"  Query failed (git tag -l, rc={r.returncode}): "
+            f"{r.stderr.strip()}. Aborting (fail-closed)."
         )
         return False
-    print_success("  Target is ancestor of origin/main")
-
-    # 1f. Local tag absent
-    print_info(f"  1f. Verifying local tag {tag_name} absent...")
-    r = _run_capture(["git", "tag", "-l", tag_name], config.project_root)
     if r.stdout.strip() == tag_name:
         print_error(f"  Local tag {tag_name} already exists.")
         return False
     print_success(f"  Local tag {tag_name} absent")
 
-    # 1g. Remote tag absent
-    print_info(f"  1g. Verifying remote tag {tag_name} absent...")
+    # 1e. Remote tag absent — distinguish not-found from query-failure
+    # using `git ls-remote --exit-code`:
+    #   rc=0  -> ref(s) found       (= tag exists, abort)
+    #   rc=2  -> no matching refs   (= tag absent, ok)
+    #   other -> network / auth     (= query failed, fail-closed)
+    print_info(f"  1e. Verifying remote tag {tag_name} absent...")
     r = _run_capture(
-        ["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag_name}"],
+        ["git", "ls-remote", "--exit-code", "--tags", "origin",
+         f"refs/tags/{tag_name}"],
         config.project_root,
     )
-    if r.stdout.strip() != "":
+    if r.returncode == 0:
         print_error(
             f"  Remote tag {tag_name} already exists:\n  {r.stdout.strip()}"
         )
         return False
-    print_success(f"  Remote tag {tag_name} absent")
+    elif r.returncode == 2:
+        print_success(
+            f"  Remote tag {tag_name} absent (ls-remote --exit-code=2)"
+        )
+    else:
+        print_error(
+            f"  Query failed (git ls-remote, rc={r.returncode}): "
+            f"{r.stderr.strip() or r.stdout.strip()}.\n"
+            "  Cannot determine whether remote tag exists. "
+            "Aborting (fail-closed)."
+        )
+        return False
 
-    # 1h. GitHub Release absent
-    print_info(f"  1h. Verifying GitHub Release {tag_name} absent...")
+    # 1f. GitHub Release absent — fail-closed on query failure.
+    #   rc=0                          -> exists, abort
+    #   rc!=0 + "release not found"   -> absent, ok
+    #   rc!=0 otherwise               -> query failed, fail-closed
+    print_info(f"  1f. Verifying GitHub Release {tag_name} absent...")
     r = _run_capture(
-        ["gh", "release", "view", tag_name], config.project_root
+        ["gh", "release", "view", tag_name, "--json", "tagName"],
+        config.project_root,
     )
     if r.returncode == 0:
         print_error(f"  GitHub Release {tag_name} already exists.")
         return False
-    print_success(f"  GitHub Release {tag_name} absent")
+    stderr_lower = (r.stderr or "").lower()
+    if "release not found" in stderr_lower:
+        print_success(f"  GitHub Release {tag_name} absent")
+    else:
+        print_error(
+            f"  Query failed (gh release view, rc={r.returncode}): "
+            f"{r.stderr.strip() or r.stdout.strip()}\n"
+            "  Cannot determine whether GitHub Release exists. "
+            "Aborting (fail-closed)."
+        )
+        return False
 
-    # 1i. Release-notes file present + non-empty
+    # 1g. Release-notes file present, non-empty, AND byte-identical to
+    # the same path committed at the target SHA. This is what guarantees
+    # the notes that ship with the Release are the ones reviewed under
+    # the target commit.
     notes_path = Path(args.release_notes_file).expanduser()
     if not notes_path.is_absolute():
         notes_path = (config.project_root / notes_path).resolve()
-    print_info(f"  1i. Verifying release-notes file: {notes_path}")
+    print_info(f"  1g. Verifying release-notes file: {notes_path}")
     if not notes_path.is_file():
         print_error(f"  Release-notes file not found: {notes_path}")
         return False
     if notes_path.stat().st_size == 0:
         print_error(f"  Release-notes file is empty: {notes_path}")
         return False
+    try:
+        rel_notes_path = notes_path.relative_to(config.project_root)
+    except ValueError:
+        print_error(
+            f"  Release-notes file {notes_path} is outside project root "
+            f"{config.project_root}; cannot verify it matches target SHA."
+        )
+        return False
+    show_r = _run_capture(
+        ["git", "show", f"{resolved_target}:{rel_notes_path}"],
+        config.project_root,
+    )
+    if show_r.returncode != 0:
+        print_error(
+            f"  Notes file {rel_notes_path} not present at target SHA "
+            f"{resolved_target[:12]}: {show_r.stderr.strip()}.\n"
+            "  The release notes must already be committed at the target SHA."
+        )
+        return False
+    tree_content = notes_path.read_text(encoding='utf-8', errors='replace')
+    git_content = show_r.stdout
+    if tree_content != git_content:
+        # Tolerate LF/CRLF normalization on platforms that round-trip
+        # text files through autocrlf — but only that.
+        if (tree_content.replace('\r\n', '\n')
+                != git_content.replace('\r\n', '\n')):
+            print_error(
+                "  Working-tree notes file content differs from the "
+                f"content committed at target SHA {resolved_target[:12]}.\n"
+                f"  Working tree: {len(tree_content)} chars\n"
+                f"  Target SHA  : {len(git_content)} chars"
+            )
+            return False
     print_success(
-        f"  Release-notes file present ({notes_path.stat().st_size} bytes)"
+        f"  Release-notes file present + matches target SHA "
+        f"({notes_path.stat().st_size} bytes)"
     )
 
-    # --- Step 2: Create DRAFT + PRERELEASE Release ---
-    print_section("\nStep 2/9: Create GitHub Release (draft, prerelease)")
-    create_cmd = [
-        "gh", "release", "create", tag_name,
-        "--draft",
-        "--prerelease",
-        "--target", resolved_target,
-        "--title", release_title,
-        "--notes-file", str(notes_path),
-    ]
-    if dry:
-        print_info(f"  [DRY-RUN] Would run: {' '.join(create_cmd)}")
-    else:
-        r = _run_capture(create_cmd, config.project_root)
-        if r.returncode != 0:
-            print_error(
-                f"  gh release create failed (rc={r.returncode}): "
-                f"{r.stderr.strip()}"
-            )
-            return False
-        print_success(
-            f"  Created draft prerelease: {r.stdout.strip() or tag_name}"
-        )
-
-    # --- Step 3: Verify Release state via re-query ---
-    print_section("\nStep 3/9: Verify Release state")
-    if dry:
-        print_info(
-            "  [DRY-RUN] Would verify isDraft=true, isPrerelease=true, "
-            f"tagName={tag_name}, targetCommitish={resolved_target[:12]}"
-        )
-    else:
-        r = _run_capture(
-            ["gh", "release", "view", tag_name,
-             "--json", "isDraft,isPrerelease,targetCommitish,tagName"],
-            config.project_root,
-        )
-        if r.returncode != 0:
-            print_error(f"  gh release view failed: {r.stderr.strip()}")
-            return False
-        try:
-            data = json.loads(r.stdout)
-        except json.JSONDecodeError as e:
-            print_error(f"  Could not parse gh release view JSON: {e}")
-            return False
-        if not data.get("isDraft"):
-            print_error(f"  Release is not draft: {data}")
-            return False
-        if not data.get("isPrerelease"):
-            print_error(f"  Release is not prerelease: {data}")
-            return False
-        if data.get("tagName") != tag_name:
-            print_error(
-                f"  Tag name mismatch: {data.get('tagName')} != {tag_name}"
-            )
-            return False
-        if data.get("targetCommitish") != resolved_target:
-            print_error(
-                "  Target commitish mismatch: "
-                f"{data.get('targetCommitish')} != {resolved_target}"
-            )
-            return False
-        print_success(
-            f"  Release verified: draft + prerelease, target={resolved_target[:12]}"
-        )
-
-    # --- Step 4: Create annotated tag locally at target SHA ---
-    print_section("\nStep 4/9: Create annotated tag locally")
+    # =====================================================================
+    # Step 2: Create local annotated tag
+    # =====================================================================
+    print_section("\nStep 2/9: Create annotated tag locally")
     tag_cmd = [
         "git", "tag", "-a", tag_name, resolved_target, "-m", tag_message,
     ]
+    state_local_tag_created = False
     if dry:
         print_info(f"  [DRY-RUN] Would run: {' '.join(tag_cmd)}")
     else:
         r = _run_capture(tag_cmd, config.project_root)
         if r.returncode != 0:
-            print_error(f"  git tag failed: {r.stderr.strip()}")
-            return False
+            print_error(
+                f"  git tag failed (rc={r.returncode}): {r.stderr.strip()}"
+            )
+            return False  # no remediation: nothing to clean up yet
+        state_local_tag_created = True
         print_success(f"  Created local annotated tag {tag_name}")
 
-    # --- Step 5: Verify local tag commit SHA ---
-    print_section("\nStep 5/9: Verify local tag SHA")
+    # =====================================================================
+    # Step 3: Verify local tag (annotated, peels to target, subject matches)
+    # =====================================================================
+    print_section("\nStep 3/9: Verify local tag is annotated + correct")
+    local_tag_obj_sha = "(unknown)"
     if dry:
         print_info(
-            f"  [DRY-RUN] Would verify {tag_name}^{{commit}} == "
-            f"{resolved_target[:12]}"
+            f"  [DRY-RUN] Would verify {tag_name}: object type=tag, "
+            f"peels to {resolved_target[:12]}, subject matches "
+            f"{tag_message.split(chr(10), 1)[0]!r}"
         )
     else:
+        # 3a. Object type must be "tag" (annotated, not lightweight).
+        r = _run_capture(
+            ["git", "cat-file", "-t", tag_name], config.project_root
+        )
+        if r.returncode != 0:
+            print_error(
+                f"  git cat-file -t failed: {r.stderr.strip()}"
+            )
+            _emit_remediation_local_tag_only(tag_name)
+            return False
+        obj_type = r.stdout.strip()
+        if obj_type != "tag":
+            print_error(
+                f"  Tag is not annotated (object type={obj_type}, expected "
+                "'tag'). Lightweight tags are rejected."
+            )
+            _emit_remediation_local_tag_only(tag_name)
+            return False
+
+        # 3b. Tag peels to target SHA.
         r = _run_capture(
             ["git", "rev-list", "-n", "1", tag_name], config.project_root
         )
         if r.returncode != 0:
             print_error(f"  git rev-list failed: {r.stderr.strip()}")
+            _emit_remediation_local_tag_only(tag_name)
             return False
         tagged_commit = r.stdout.strip()
         if tagged_commit != resolved_target:
             print_error(
-                f"  Tag commit {tagged_commit} != expected {resolved_target}"
+                f"  Tag commit {tagged_commit} != expected "
+                f"{resolved_target}"
             )
+            _emit_remediation_local_tag_only(tag_name)
             return False
-        print_success(f"  Local tag {tag_name} -> {tagged_commit}")
 
-    # --- Step 6: Push tag only (NOT main) ---
-    print_section("\nStep 6/9: Push tag to origin (tag only)")
-    push_cmd = ["git", "push", "origin", tag_name]
+        # 3c. Tag subject matches first line of expected message.
+        r = _run_capture(
+            ["git", "tag", "-l", "--format=%(contents:subject)", tag_name],
+            config.project_root,
+        )
+        if r.returncode != 0:
+            print_error(
+                f"  git tag -l --format failed: {r.stderr.strip()}"
+            )
+            _emit_remediation_local_tag_only(tag_name)
+            return False
+        actual_subject = r.stdout.strip()
+        expected_subject = tag_message.split('\n', 1)[0].strip()
+        if actual_subject != expected_subject:
+            print_error(
+                "  Tag subject mismatch.\n"
+                f"  Expected: {expected_subject!r}\n"
+                f"  Actual  : {actual_subject!r}"
+            )
+            _emit_remediation_local_tag_only(tag_name)
+            return False
+
+        # 3d. Capture tag object SHA for reporting.
+        r = _run_capture(
+            ["git", "rev-parse", tag_name], config.project_root
+        )
+        if r.returncode == 0:
+            local_tag_obj_sha = r.stdout.strip()
+
+        print_success(
+            f"  Annotated tag {tag_name} OK (obj={local_tag_obj_sha[:12]}, "
+            f"commit={tagged_commit[:12]}, subject={actual_subject!r})"
+        )
+
+    # =====================================================================
+    # Step 4: Capture before_push timestamp + push tag only
+    # =====================================================================
+    print_section("\nStep 4/9: Push tag to origin (tag only)")
+    push_cmd = ["git", "push", "origin", f"refs/tags/{tag_name}"]
+    before_push_dt = None
+    state_remote_tag_pushed = False
     if dry:
-        print_info(f"  [DRY-RUN] Would run: {' '.join(push_cmd)}")
+        print_info(
+            "  [DRY-RUN] Would capture before_push UTC timestamp, then "
+            f"run: {' '.join(push_cmd)}"
+        )
     else:
+        before_push_dt = datetime.now(timezone.utc)
+        before_push_iso = before_push_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        print_info(f"  before_push = {before_push_iso}")
         r = _run_capture(push_cmd, config.project_root)
         if r.returncode != 0:
-            print_error(f"  git push failed: {r.stderr.strip()}")
+            print_error(
+                f"  git push failed (rc={r.returncode}): {r.stderr.strip()}"
+            )
+            _emit_remediation_local_tag_only(tag_name)
             return False
+        state_remote_tag_pushed = True
         print_success(f"  Pushed tag {tag_name}")
 
-    # --- Step 7: Verify remote tag commit matches local ---
-    print_section("\nStep 7/9: Verify remote tag")
+    # =====================================================================
+    # Step 5: Verify remote tag peels to target SHA
+    # =====================================================================
+    print_section("\nStep 5/9: Verify remote tag")
     if dry:
         print_info(
             f"  [DRY-RUN] Would verify origin {tag_name} -> "
@@ -1165,7 +1394,8 @@ def create_rc_release(config, adapter, args) -> bool:
         )
     else:
         r = _run_capture(
-            ["git", "ls-remote", "--tags", "origin", f"refs/tags/{tag_name}"],
+            ["git", "ls-remote", "--tags", "origin",
+             f"refs/tags/{tag_name}"],
             config.project_root,
         )
         if r.returncode != 0 or r.stdout.strip() == "":
@@ -1173,10 +1403,11 @@ def create_rc_release(config, adapter, args) -> bool:
                 f"  Remote tag {tag_name} not visible after push:\n"
                 f"  stdout={r.stdout!r} stderr={r.stderr.strip()!r}"
             )
+            _emit_remediation_remote_tag_only(tag_name)
             return False
-        # ls-remote prints <obj-sha>\t<ref>; for annotated tags it also
-        # prints a peeled "<commit-sha>\trefs/tags/<tag>^{}" entry — that's
-        # the commit we want to compare against resolved_target.
+        # `ls-remote` prints "<obj-sha>\t<ref>" lines. For an annotated tag
+        # it also prints a peeled "<commit-sha>\trefs/tags/<tag>^{}" line —
+        # that's the commit we compare against resolved_target.
         peeled = None
         for line in r.stdout.strip().splitlines():
             parts = line.split(None, 1)
@@ -1187,32 +1418,135 @@ def create_rc_release(config, adapter, args) -> bool:
                 peeled = sha
                 break
         if peeled is None:
-            # No peeled ref (lightweight tag, unexpected here): take the
-            # single ref line as the commit.
-            first = r.stdout.strip().splitlines()[0].split(None, 1)
-            peeled = first[0] if first else ""
+            print_error(
+                "  Remote tag has no peeled ref — likely a lightweight tag, "
+                "which is rejected. ls-remote output:\n"
+                f"  {r.stdout.strip()}"
+            )
+            _emit_remediation_remote_tag_only(tag_name)
+            return False
         if peeled != resolved_target:
             print_error(
                 f"  Remote tag commit {peeled} != expected {resolved_target}"
             )
+            _emit_remediation_remote_tag_only(tag_name)
             return False
-        print_success(f"  Remote tag {tag_name} -> {peeled}")
+        print_success(
+            f"  Remote tag {tag_name} -> {peeled} "
+            f"(local obj={local_tag_obj_sha[:12]})"
+        )
 
-    # --- Step 8: Locate the new release-linux.yml run ---
-    print_section("\nStep 8/9: Locate release-linux workflow run")
+    # =====================================================================
+    # Step 6: Create GitHub draft prerelease using existing remote tag.
+    # `--verify-tag` makes gh refuse the call if the tag does not already
+    # exist on the remote — closing the door on accidental tag auto-create.
+    # =====================================================================
+    print_section(
+        "\nStep 6/9: Create GitHub Release (draft, prerelease, --verify-tag)"
+    )
+    create_cmd = [
+        "gh", "release", "create", tag_name,
+        "--draft",
+        "--prerelease",
+        "--verify-tag",
+        "--title", release_title,
+        "--notes-file", str(notes_path),
+    ]
+    state_release_created = False
+    if dry:
+        print_info(f"  [DRY-RUN] Would run: {' '.join(create_cmd)}")
+    else:
+        r = _run_capture(create_cmd, config.project_root)
+        if r.returncode != 0:
+            print_error(
+                f"  gh release create failed (rc={r.returncode}): "
+                f"{r.stderr.strip()}"
+            )
+            _emit_remediation_remote_tag_only(tag_name)
+            return False
+        state_release_created = True
+        print_success(
+            f"  Created draft prerelease: {r.stdout.strip() or tag_name}"
+        )
+
+    # =====================================================================
+    # Step 7: Verify Release state via re-query
+    # =====================================================================
+    print_section("\nStep 7/9: Verify Release state")
+    if dry:
+        print_info(
+            "  [DRY-RUN] Would verify isDraft=true, isPrerelease=true, "
+            f"tagName={tag_name}"
+        )
+    else:
+        r = _run_capture(
+            ["gh", "release", "view", tag_name,
+             "--json", "isDraft,isPrerelease,tagName"],
+            config.project_root,
+        )
+        if r.returncode != 0:
+            print_error(f"  gh release view failed: {r.stderr.strip()}")
+            _emit_remediation_release_created(tag_name)
+            return False
+        try:
+            data = json.loads(r.stdout)
+        except json.JSONDecodeError as e:
+            print_error(f"  Could not parse gh release view JSON: {e}")
+            _emit_remediation_release_created(tag_name)
+            return False
+        if not data.get("isDraft"):
+            print_error(f"  Release is not draft: {data}")
+            _emit_remediation_release_created(tag_name)
+            return False
+        if not data.get("isPrerelease"):
+            print_error(f"  Release is not prerelease: {data}")
+            _emit_remediation_release_created(tag_name)
+            return False
+        if data.get("tagName") != tag_name:
+            print_error(
+                f"  Tag name mismatch: {data.get('tagName')} != {tag_name}"
+            )
+            _emit_remediation_release_created(tag_name)
+            return False
+        # targetCommitish on a Release created with --verify-tag may be
+        # reported as the default branch name (e.g., "main") rather than
+        # the commit SHA, because the tag→SHA binding lives on the tag
+        # itself — which step 5 has already verified.
+        print_success(
+            f"  Release verified: draft + prerelease, tagName={tag_name}"
+        )
+
+    # =====================================================================
+    # Step 8: Confirm release-linux.yml run started (HARD FAILURE if not)
+    # Filter criteria:
+    #   workflow == release-linux.yml
+    #   event    == push
+    #   createdAt >= before_push_iso - 30s  (clock-skew tolerance)
+    #   headBranch == tag_name OR headSha == resolved_target
+    # =====================================================================
+    print_section("\nStep 8/9: Confirm release-linux.yml workflow run")
     new_run = None
     if dry:
         print_info(
-            "  [DRY-RUN] Would query gh run list "
-            "--workflow=release-linux.yml --json …"
+            "  [DRY-RUN] Would filter `gh run list "
+            "--workflow=release-linux.yml --event=push` by createdAt >= "
+            "before_push - 30s AND (headBranch == tag OR headSha == "
+            "target). HARD FAILURE if no match within ~40 s."
         )
     else:
-        for attempt in range(6):  # up to ~30s
+        filter_floor_dt = before_push_dt - timedelta(seconds=30)
+        filter_floor_iso = filter_floor_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        print_info(
+            f"  Filter floor (before_push - 30s) = {filter_floor_iso}"
+        )
+        for attempt in range(8):  # up to ~40 s
             r = _run_capture(
                 ["gh", "run", "list",
                  "--workflow=release-linux.yml",
-                 "--limit", "10",
-                 "--json", "databaseId,event,headBranch,status,createdAt,url"],
+                 "--event=push",
+                 "--limit", "20",
+                 "--json",
+                 "databaseId,event,headBranch,headSha,status,createdAt,url"],
                 config.project_root,
             )
             if r.returncode == 0:
@@ -1221,26 +1555,43 @@ def create_rc_release(config, adapter, args) -> bool:
                 except json.JSONDecodeError:
                     runs = []
                 for run in runs:
-                    # Tag-triggered workflows: gh sets headBranch to the tag.
-                    if run.get("headBranch") == tag_name:
-                        new_run = run
-                        break
+                    if run.get("event") != "push":
+                        continue
+                    created_at = run.get("createdAt") or ""
+                    if created_at < filter_floor_iso:
+                        continue
+                    head_branch = run.get("headBranch") or ""
+                    head_sha = run.get("headSha") or ""
+                    if (head_branch != tag_name
+                            and head_sha != resolved_target):
+                        continue
+                    new_run = run
+                    break
             if new_run is not None:
                 break
             time.sleep(5)
         if new_run is None:
-            print_warning(
-                f"  Did not locate release-linux run for {tag_name} within "
-                "30s. The workflow may still be queueing; check the Actions "
-                "tab manually."
+            print_error(
+                "  HARD FAILURE: release-linux.yml run not found within "
+                "40 s of tag push.\n"
+                "  Filter criteria:\n"
+                "    workflow  = release-linux.yml\n"
+                "    event     = push\n"
+                f"    createdAt >= {filter_floor_iso}\n"
+                f"    headBranch == {tag_name} OR headSha == "
+                f"{resolved_target[:12]}\n"
             )
-        else:
-            print_success(
-                f"  Found run {new_run['databaseId']} "
-                f"(status={new_run.get('status', 'unknown')})"
-            )
+            _emit_remediation_workflow_missing(tag_name)
+            return False
+        print_success(
+            f"  Found run {new_run['databaseId']} "
+            f"(status={new_run.get('status', 'unknown')}, "
+            f"createdAt={new_run.get('createdAt')})"
+        )
 
-    # --- Step 9: Summary + manual next steps ---
+    # =====================================================================
+    # Step 9: Summary + manual next steps
+    # =====================================================================
     print_section("\nStep 9/9: Summary")
     print_section(f"\n{'='*70}")
     print_success(
@@ -1249,6 +1600,8 @@ def create_rc_release(config, adapter, args) -> bool:
     )
     print_section(f"{'='*70}")
     print_info(f"Tag      : {tag_name} -> {resolved_target}")
+    if not dry:
+        print_info(f"Tag obj  : {local_tag_obj_sha}")
     if config.project_url:
         print_info(
             f"Release  : {config.project_url}/releases/tag/{tag_name}"
@@ -1259,7 +1612,7 @@ def create_rc_release(config, adapter, args) -> bool:
         print_info(f"CI state : {new_run.get('status', 'unknown')}")
     print_info("")
     print_info("NEXT STEPS (manual, after CI passes and artifacts uploaded):")
-    print_info(f"  1. Smoke-test the release-linux.yml artifacts.")
+    print_info("  1. Smoke-test the release-linux.yml artifacts.")
     print_info(f"  2. Publish: gh release edit {tag_name} --draft=false")
     print()
     return True


### PR DESCRIPTION
## Summary

Adds `release.py rc-tag <version> --target <SHA> --release-notes-file <PATH>` for landing a release-candidate tag at an explicit commit as a **draft, prerelease** GitHub Release. The existing `release` action is unchanged.

Distinct from `release` in three safety-relevant ways:

1. **Tags the explicit `--target` SHA** — not `HEAD` and not blindly tied to whatever `main` happens to be when the command runs.
2. **Pushes the tag only** — never pushes `main`.
3. **Creates the Release as `--draft --prerelease`** — so the maintainer can review the `release-linux.yml` workflow output and smoke-test the artifacts before manually publishing.

## Boundary discipline

Every `gh` / `git` boundary operation is followed by an explicit post-state re-query verification step. Silent return is never inferred as success. The 9 ordered steps:

| Step | Action | Verification |
|---|---|---|
| 1 | Preflight (9 subchecks: tree clean, fresh fetch, local main == origin/main, target resolves, target ancestor of origin/main, local tag absent, remote tag absent, GH Release absent, notes file present + non-empty) | Each subcheck has its own re-query |
| 2 | `gh release create --draft --prerelease --target <SHA>` | (mutation) |
| 3 | — | `gh release view --json isDraft,isPrerelease,targetCommitish,tagName` |
| 4 | `git tag -a <tag> <SHA> -m <msg>` | (mutation) |
| 5 | — | `git rev-list -n 1 <tag>` == `<SHA>` |
| 6 | `git push origin <tag>` (tag only) | (mutation) |
| 7 | — | `git ls-remote --tags origin refs/tags/<tag>` peeled SHA == `<SHA>` |
| 8 | Locate `release-linux.yml` run dispatched by the tag push | `gh run list --json …`; retries up to ~30s |
| 9 | Print summary + manual publish step (`gh release edit <tag> --draft=false`) | — |

`--dry-run` runs every read-only preflight verification but skips every mutation (steps 2, 4, 6) and the post-mutation verifications (3, 5, 7, 8).

## What is intentionally NOT changed

- The existing `prepare` / `release` / `validate` actions and their adapter contracts are byte-identical.
- No adapter methods were added or modified. `rc-tag` is repo-agnostic (pure git + gh).
- No version mutation (`alire.toml` / `go.mod`). RC version bumps remain the `prepare` action's responsibility.
- No SPARK post-verify, no auto-commit, no main push, no draft auto-publish.

## Validation evidence

Dry-run against `adafmt` `fb2ffee54b91095bef127cb31b799b9e6691ec53`:

\`\`\`
$ python3 release/release.py rc-tag 1.0.0-rc3 \\
    --project-root /Users/mike/Ada/github.com/abitofhelp/adafmt \\
    --target fb2ffee54b91095bef127cb31b799b9e6691ec53 \\
    --release-notes-file docs/release_notes/v1.0.0_draft.md \\
    --tag-message 'Release candidate 1.0.0-rc3' \\
    --release-title 'Release 1.0.0-rc3 (release candidate)' \\
    --dry-run
\`\`\`

Result: exit 0. All 9 preflight subchecks pass (tree clean, fetch ok, `main == origin/main == fb2ffee54b91`, target resolves to full SHA, target is ancestor of origin/main, local tag absent, remote tag absent, GH Release absent, notes file 7410 bytes). Mutation/verification steps surface their exact commands. Summary + manual next steps render.

Argparse validations also exercised:
- Missing `--target` / `--release-notes-file` → rc-tag aborts with explicit error.
- Non-hex / wrong-length `--target` → aborts with explicit error.
- Bad semver → existing semver validator catches.

## Test plan

- [ ] PR diff review on `release/release.py` (additive `create_rc_release`, additive argparse, additive dispatch branch) + `release/models.py` (new `RC_TAG` enum entry)
- [ ] Confirm no behavioral change to `prepare` / `release` / `validate` (diff shows only additions in their argparse + dispatch areas)
- [ ] Optional Codex / GPT second-pass review on the diff before merge
- [ ] After merge: refresh the submodule pin in adafmt (and other consumers as needed) before invoking `rc-tag` from a consumer

Per maintainer directive: **do not merge** — this PR is for review only.