### PR TITLE
fix(rc-tag): verify remote annotated tag via gh api Git Data dereference

### DIFF
--- a/release/release.py
+++ b/release/release.py
@@ -888,6 +888,145 @@ def _run_capture(cmd, cwd):
     )
 
 
+def _verify_remote_annotated_tag(
+    project_root,
+    tag_name,
+    expected_target_sha,
+    expected_message,
+):
+    """Verify a remote annotated tag against a target commit + message via
+    the GitHub Git Data API.
+
+    Why not `git ls-remote`: on GitHub's smart-HTTP protocol, an exact-ref
+    refspec like ``refs/tags/<tag>`` returns only the tag-object line and
+    omits the peeled ``^{}`` line. The protocol is allowed to do this for
+    exact-ref discovery (the peeled-commit advertisement is optional), so
+    verifying the target commit from ``git ls-remote`` alone is unreliable
+    on GitHub remotes. The Git Data API instead returns object types and
+    target SHAs as explicit JSON fields and is authoritative.
+
+    This function bit the rc-tag flow on adafmt v1.0.0-rc3 (2026-06-12).
+
+    Verifies, in order, all five of:
+      1. ``refs/tags/<tag>`` ref exists on the remote.
+      2. ref object type is ``"tag"`` (annotated; lightweight rejected).
+      3. tag object's ``object.type`` is ``"commit"``.
+      4. tag object's ``object.sha`` equals ``expected_target_sha``.
+      5. tag object's ``message`` equals ``expected_message`` after
+         trailing-newline normalisation on both sides.
+
+    The function is intentionally side-effect-free (read-only `gh api`
+    calls) and returns a tuple instead of printing, so it can be unit-
+    tested by mocking ``subprocess.run``.
+
+    Args:
+        project_root:        cwd for the ``gh`` CLI calls; ``gh`` auto-
+                             detects the GitHub repo from the cwd's
+                             git remote.
+        tag_name:            e.g. ``"v1.0.0-rc3"``.
+        expected_target_sha: full 40-char commit SHA the tag should peel
+                             to.
+        expected_message:    full annotated tag message expected on the
+                             remote. Trailing newlines are normalised
+                             out before comparison; internal whitespace,
+                             blank lines, and body structure are
+                             compared verbatim.
+
+    Returns:
+        ``(ok, diagnostic)``. On success, ``diagnostic`` is a short
+        one-line descriptor of what was verified. On failure,
+        ``diagnostic`` explains exactly which sub-check failed and why.
+    """
+    # 1. Resolve owner/repo so we can build absolute Git Data API paths.
+    r = _run_capture(
+        ["gh", "repo", "view", "--json", "owner,name",
+         "--jq", "\"\\(.owner.login)/\\(.name)\""],
+        project_root,
+    )
+    if r.returncode != 0 or not r.stdout.strip():
+        return False, (
+            f"gh repo view failed (rc={r.returncode}): "
+            f"{r.stderr.strip() or r.stdout.strip()}"
+        )
+    owner_repo = r.stdout.strip().strip('"')
+
+    # 2. Fetch the tag ref. Non-zero rc covers both "not found" and
+    # auth/network failure; either way, fail closed.
+    r = _run_capture(
+        ["gh", "api",
+         f"repos/{owner_repo}/git/refs/tags/{tag_name}",
+         "--jq", "{type: .object.type, sha: .object.sha}"],
+        project_root,
+    )
+    if r.returncode != 0:
+        return False, (
+            f"gh api repos/{owner_repo}/git/refs/tags/{tag_name} failed "
+            f"(rc={r.returncode}): {r.stderr.strip() or r.stdout.strip()}"
+        )
+    try:
+        ref_data = json.loads(r.stdout)
+    except json.JSONDecodeError as e:
+        return False, f"git/refs/tags JSON parse error: {e}; stdout={r.stdout!r}"
+
+    # 3. Reject lightweight tags. GitHub reports a lightweight tag's ref
+    # object.type as "commit" (it points straight at the commit, no
+    # intermediate tag object). Annotated tags report "tag".
+    ref_obj_type = ref_data.get("type")
+    if ref_obj_type != "tag":
+        return False, (
+            f"remote ref object type is {ref_obj_type!r}, expected 'tag' "
+            f"(annotated; lightweight tags are rejected)"
+        )
+    tag_obj_sha = ref_data.get("sha")
+    if not tag_obj_sha:
+        return False, "git/refs/tags response missing object.sha"
+
+    # 4. Fetch the tag object to get target type, target SHA, and message.
+    r = _run_capture(
+        ["gh", "api",
+         f"repos/{owner_repo}/git/tags/{tag_obj_sha}",
+         "--jq",
+         "{target_type: .object.type, target_sha: .object.sha, "
+         "message: .message}"],
+        project_root,
+    )
+    if r.returncode != 0:
+        return False, (
+            f"gh api repos/{owner_repo}/git/tags/{tag_obj_sha} failed "
+            f"(rc={r.returncode}): {r.stderr.strip() or r.stdout.strip()}"
+        )
+    try:
+        tag_data = json.loads(r.stdout)
+    except json.JSONDecodeError as e:
+        return False, f"git/tags JSON parse error: {e}; stdout={r.stdout!r}"
+
+    # 5. Verify target type, target SHA, and message.
+    target_type = tag_data.get("target_type")
+    if target_type != "commit":
+        return False, (
+            f"remote tag target type is {target_type!r}, expected 'commit'"
+        )
+    target_sha_remote = tag_data.get("target_sha") or ""
+    if target_sha_remote != expected_target_sha:
+        return False, (
+            f"remote tag target {target_sha_remote} != expected "
+            f"{expected_target_sha}"
+        )
+    remote_msg = (tag_data.get("message") or "").rstrip('\n')
+    expected_norm = (expected_message or "").rstrip('\n')
+    if remote_msg != expected_norm:
+        return False, (
+            f"remote tag message mismatch — "
+            f"expected ({len(expected_norm)} chars): {expected_norm!r}; "
+            f"remote ({len(remote_msg)} chars): {remote_msg!r}"
+        )
+
+    return True, (
+        f"obj={tag_obj_sha[:12]}, target={target_sha_remote[:12]}, "
+        f"msg={len(remote_msg)} chars"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Partial-state remediation messages for rc-tag.
 #
@@ -1413,55 +1552,41 @@ def create_rc_release(config, adapter, args) -> bool:
         print_success(f"  Pushed tag {tag_name}")
 
     # =====================================================================
-    # Step 5: Verify remote tag peels to target SHA
+    # Step 5: Verify remote tag (annotated + correct target + correct
+    # message) via GitHub Git Data API dereference.
+    #
+    # Note: a `git ls-remote --tags origin refs/tags/<tag>` exact-ref
+    # query on GitHub smart-HTTP returns only the tag-object line, never
+    # the peeled `^{}` line — so verifying the target commit from
+    # ls-remote alone is unreliable. The Git Data API is authoritative.
+    # See _verify_remote_annotated_tag for the full rationale.
     # =====================================================================
-    print_section("\nStep 5/9: Verify remote tag")
+    print_section(
+        "\nStep 5/9: Verify remote tag (via gh api Git Data dereference)"
+    )
     if dry:
+        _exp_msg_norm = (tag_message or "").rstrip('\n')
         print_info(
-            f"  [DRY-RUN] Would verify origin {tag_name} -> "
-            f"{resolved_target[:12]}"
+            f"  [DRY-RUN] Would verify via gh api: "
+            f"refs/tags/{tag_name} object type=tag, "
+            f"target type=commit, target SHA={resolved_target[:12]}, "
+            f"message matches expected ({len(_exp_msg_norm)} chars)"
         )
     else:
-        r = _run_capture(
-            ["git", "ls-remote", "--tags", "origin",
-             f"refs/tags/{tag_name}"],
-            config.project_root,
+        ok, diag = _verify_remote_annotated_tag(
+            project_root=config.project_root,
+            tag_name=tag_name,
+            expected_target_sha=resolved_target,
+            expected_message=tag_message,
         )
-        if r.returncode != 0 or r.stdout.strip() == "":
+        if not ok:
             print_error(
-                f"  Remote tag {tag_name} not visible after push:\n"
-                f"  stdout={r.stdout!r} stderr={r.stderr.strip()!r}"
-            )
-            _emit_remediation_remote_tag_only(tag_name)
-            return False
-        # `ls-remote` prints "<obj-sha>\t<ref>" lines. For an annotated tag
-        # it also prints a peeled "<commit-sha>\trefs/tags/<tag>^{}" line —
-        # that's the commit we compare against resolved_target.
-        peeled = None
-        for line in r.stdout.strip().splitlines():
-            parts = line.split(None, 1)
-            if len(parts) != 2:
-                continue
-            sha, ref = parts[0], parts[1].strip()
-            if ref == f"refs/tags/{tag_name}^{{}}":
-                peeled = sha
-                break
-        if peeled is None:
-            print_error(
-                "  Remote tag has no peeled ref — likely a lightweight tag, "
-                "which is rejected. ls-remote output:\n"
-                f"  {r.stdout.strip()}"
-            )
-            _emit_remediation_remote_tag_only(tag_name)
-            return False
-        if peeled != resolved_target:
-            print_error(
-                f"  Remote tag commit {peeled} != expected {resolved_target}"
+                f"  Remote tag verification failed: {diag}"
             )
             _emit_remediation_remote_tag_only(tag_name)
             return False
         print_success(
-            f"  Remote tag {tag_name} -> {peeled} "
+            f"  Remote tag {tag_name} verified — {diag} "
             f"(local obj={local_tag_obj_sha[:12]})"
         )
 

--- a/tests/test_rc_tag_remote_tag_verification.py
+++ b/tests/test_rc_tag_remote_tag_verification.py
@@ -1,0 +1,344 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Michael Gardner, A Bit of Help, Inc.
+"""Unit tests for ``release.release._verify_remote_annotated_tag``.
+
+This is the rc-tag Step 5 fix. The previous implementation used
+``git ls-remote --tags origin refs/tags/<tag>`` which on GitHub's
+smart-HTTP protocol returns ONLY the tag-object line for exact-ref
+queries and omits the peeled ``^{}`` line. That misclassified perfectly
+valid annotated tags as lightweight (observed on the real adafmt
+v1.0.0-rc3 invocation, 2026-06-12).
+
+The fix uses the GitHub Git Data API instead:
+
+  1. ``GET repos/{owner}/{repo}/git/refs/tags/<tag>`` — confirm the ref
+     exists and its ``object.type`` is ``"tag"`` (annotated). A
+     lightweight tag would report ``"commit"``.
+  2. ``GET repos/{owner}/{repo}/git/tags/<obj-sha>`` — read
+     ``object.type``, ``object.sha`` (target commit) and ``message``;
+     confirm all three.
+
+These tests mock ``subprocess.run`` so no network access or real
+``gh`` CLI is required. Each test scripts the response sequence
+``gh repo view`` -> ``gh api git/refs/tags`` -> ``gh api git/tags``.
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Callable, List, Sequence, Tuple
+
+import pytest
+
+from release.release import _verify_remote_annotated_tag
+
+
+# ----------------------------------------------------------------------
+# Test helpers — script subprocess.run responses by command shape
+# ----------------------------------------------------------------------
+
+def _cp(stdout: str = "", returncode: int = 0, stderr: str = ""):
+    """Mimic a subprocess.CompletedProcess just enough for our code."""
+    return SimpleNamespace(
+        stdout=stdout, stderr=stderr, returncode=returncode
+    )
+
+
+class _FakeRunner:
+    """Scripted ``subprocess.run`` substitute.
+
+    Each entry in ``responses`` is ``(matcher(cmd) -> bool, completed_process)``.
+    The first matcher that accepts a command supplies the response. Calls
+    are recorded in ``self.calls`` for assertion.
+    """
+
+    def __init__(
+        self,
+        responses: Sequence[Tuple[Callable[[List[str]], bool], SimpleNamespace]],
+    ):
+        self.responses = list(responses)
+        self.calls: List[List[str]] = []
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        for matcher, response in self.responses:
+            if matcher(cmd):
+                return response
+        return _cp(
+            "", returncode=1, stderr=f"unexpected cmd: {cmd}"
+        )
+
+
+# Matchers
+def _is_gh_repo_view(cmd):
+    return cmd[:3] == ["gh", "repo", "view"]
+
+
+def _is_gh_api_refs_tags(cmd):
+    return (
+        len(cmd) >= 3
+        and cmd[:2] == ["gh", "api"]
+        and "git/refs/tags/" in cmd[2]
+    )
+
+
+def _is_gh_api_git_tags(cmd):
+    return (
+        len(cmd) >= 3
+        and cmd[:2] == ["gh", "api"]
+        and "/git/tags/" in cmd[2]
+        and "git/refs/tags/" not in cmd[2]
+    )
+
+
+# Fixtures
+TARGET = "7567c5ef8587fb0e8e633e53fe8487d26696ae34"
+TAG_OBJ = "9f6628e33f718a1a51ebeabc766b9a3a13f7b809"
+TAG_NAME = "v1.0.0-rc3"
+MSG = "adafmt v1.0.0-rc3 — third release candidate"
+
+
+def _repo_view_ok():
+    return _cp('"abitofhelp/adafmt"', returncode=0)
+
+
+def _refs_tags_annotated_ok():
+    return _cp(json.dumps({"type": "tag", "sha": TAG_OBJ}), returncode=0)
+
+
+def _git_tags_ok(target_sha=TARGET, message=MSG + "\n"):
+    return _cp(
+        json.dumps({
+            "target_type": "commit",
+            "target_sha": target_sha,
+            "message": message,
+        }),
+        returncode=0,
+    )
+
+
+# ----------------------------------------------------------------------
+# Scenario 1: correct annotated remote tag is accepted
+# ----------------------------------------------------------------------
+
+def test_accepts_correct_annotated_remote_tag(monkeypatch):
+    runner = _FakeRunner([
+        (_is_gh_repo_view, _repo_view_ok()),
+        (_is_gh_api_refs_tags, _refs_tags_annotated_ok()),
+        (_is_gh_api_git_tags, _git_tags_ok()),
+    ])
+    monkeypatch.setattr("release.release.subprocess.run", runner)
+
+    ok, diag = _verify_remote_annotated_tag(
+        project_root=Path("/tmp/fake"),
+        tag_name=TAG_NAME,
+        expected_target_sha=TARGET,
+        expected_message=MSG,
+    )
+    assert ok, f"expected success but got: {diag}"
+    # Diagnostic includes the verified short SHAs and message length
+    assert "obj=" + TAG_OBJ[:12] in diag
+    assert "target=" + TARGET[:12] in diag
+    assert "msg=" in diag
+
+
+# ----------------------------------------------------------------------
+# Scenario 2: lightweight remote tag is rejected
+# ----------------------------------------------------------------------
+
+def test_rejects_lightweight_remote_tag(monkeypatch):
+    """A lightweight tag reports object.type == "commit" on the ref."""
+    runner = _FakeRunner([
+        (_is_gh_repo_view, _repo_view_ok()),
+        (_is_gh_api_refs_tags, _cp(
+            json.dumps({"type": "commit", "sha": TARGET}),
+            returncode=0,
+        )),
+    ])
+    monkeypatch.setattr("release.release.subprocess.run", runner)
+
+    ok, diag = _verify_remote_annotated_tag(
+        Path("/tmp/fake"), TAG_NAME, TARGET, MSG
+    )
+    assert not ok
+    assert "lightweight" in diag.lower() or "'commit'" in diag
+
+
+# ----------------------------------------------------------------------
+# Scenario 3: annotated tag pointing to wrong target is rejected
+# ----------------------------------------------------------------------
+
+def test_rejects_annotated_tag_with_wrong_target(monkeypatch):
+    """Annotated tag whose .object.sha != expected target — rejected."""
+    runner = _FakeRunner([
+        (_is_gh_repo_view, _repo_view_ok()),
+        (_is_gh_api_refs_tags, _refs_tags_annotated_ok()),
+        (_is_gh_api_git_tags, _git_tags_ok(
+            target_sha="0000000000000000000000000000000000000000"
+        )),
+    ])
+    monkeypatch.setattr("release.release.subprocess.run", runner)
+
+    ok, diag = _verify_remote_annotated_tag(
+        Path("/tmp/fake"), TAG_NAME, TARGET, MSG
+    )
+    assert not ok
+    assert "target" in diag.lower() and "!=" in diag
+
+
+# ----------------------------------------------------------------------
+# Scenario 4: missing remote tag is rejected
+# ----------------------------------------------------------------------
+
+def test_rejects_missing_remote_tag(monkeypatch):
+    """gh api returns rc=1 for the refs/tags lookup — caught + rejected."""
+    runner = _FakeRunner([
+        (_is_gh_repo_view, _repo_view_ok()),
+        (_is_gh_api_refs_tags, _cp(
+            stdout="", returncode=1, stderr="gh: not found (HTTP 404)"
+        )),
+    ])
+    monkeypatch.setattr("release.release.subprocess.run", runner)
+
+    ok, diag = _verify_remote_annotated_tag(
+        Path("/tmp/fake"), TAG_NAME, TARGET, MSG
+    )
+    assert not ok
+    assert "refs/tags" in diag.lower()
+    assert "rc=1" in diag
+
+
+# ----------------------------------------------------------------------
+# Scenario 5: REGRESSION for the v1.0.0-rc3 partial state.
+#
+# We don't call ``git ls-remote`` at all in the fixed code path, but
+# the function still has to succeed for a correctly-annotated tag —
+# proving that the rc3 partial-state regression cannot recur, since
+# exact-ref ls-remote behaviour is no longer load-bearing.
+# ----------------------------------------------------------------------
+
+def test_regression_v1_0_0_rc3_partial_state(monkeypatch):
+    """With the fix, the rc3-shaped tag verifies successfully and no
+    ``git ls-remote`` call is made (the formerly-buggy command)."""
+    runner = _FakeRunner([
+        (_is_gh_repo_view, _repo_view_ok()),
+        (_is_gh_api_refs_tags, _refs_tags_annotated_ok()),
+        (_is_gh_api_git_tags, _git_tags_ok()),
+    ])
+    monkeypatch.setattr("release.release.subprocess.run", runner)
+
+    ok, diag = _verify_remote_annotated_tag(
+        Path("/tmp/fake"), TAG_NAME, TARGET, MSG
+    )
+    assert ok, diag
+    # No call to git ls-remote occurred
+    for call in runner.calls:
+        assert call[:2] != ["git", "ls-remote"], (
+            f"ls-remote was reintroduced: {call}"
+        )
+
+
+# ----------------------------------------------------------------------
+# Scenario 6: tag message mismatch is rejected
+# ----------------------------------------------------------------------
+
+def test_rejects_tag_with_wrong_message(monkeypatch):
+    runner = _FakeRunner([
+        (_is_gh_repo_view, _repo_view_ok()),
+        (_is_gh_api_refs_tags, _refs_tags_annotated_ok()),
+        (_is_gh_api_git_tags, _git_tags_ok(
+            message="some completely different message\n"
+        )),
+    ])
+    monkeypatch.setattr("release.release.subprocess.run", runner)
+
+    ok, diag = _verify_remote_annotated_tag(
+        Path("/tmp/fake"), TAG_NAME, TARGET, MSG
+    )
+    assert not ok
+    assert "message" in diag.lower()
+
+
+# ----------------------------------------------------------------------
+# Scenario 7: trailing-newline normalisation (both sides) — match
+# ----------------------------------------------------------------------
+
+def test_trailing_newline_normalised_on_both_sides(monkeypatch):
+    """Remote has trailing '\\n', expected has none — should match."""
+    runner = _FakeRunner([
+        (_is_gh_repo_view, _repo_view_ok()),
+        (_is_gh_api_refs_tags, _refs_tags_annotated_ok()),
+        (_is_gh_api_git_tags, _git_tags_ok(
+            message="msg with trailing newline\n"
+        )),
+    ])
+    monkeypatch.setattr("release.release.subprocess.run", runner)
+
+    ok, diag = _verify_remote_annotated_tag(
+        Path("/tmp/fake"), TAG_NAME, TARGET,
+        expected_message="msg with trailing newline",  # no '\n'
+    )
+    assert ok, diag
+
+
+# ----------------------------------------------------------------------
+# Scenario 8: multi-line tag message round-trips verbatim
+# ----------------------------------------------------------------------
+
+def test_multiline_tag_message_verbatim_compare(monkeypatch):
+    """Internal blank lines + paragraph structure preserved across
+    normalisation; both sides match — accepted."""
+    multi = "Subject line\n\nFirst body paragraph.\n\nSecond paragraph."
+    runner = _FakeRunner([
+        (_is_gh_repo_view, _repo_view_ok()),
+        (_is_gh_api_refs_tags, _refs_tags_annotated_ok()),
+        (_is_gh_api_git_tags, _git_tags_ok(message=multi + "\n")),
+    ])
+    monkeypatch.setattr("release.release.subprocess.run", runner)
+
+    ok, diag = _verify_remote_annotated_tag(
+        Path("/tmp/fake"), TAG_NAME, TARGET, multi
+    )
+    assert ok, diag
+
+
+# ----------------------------------------------------------------------
+# Scenario 9: gh api returns malformed JSON — fail-closed
+# ----------------------------------------------------------------------
+
+def test_malformed_refs_tags_json_fails_closed(monkeypatch):
+    runner = _FakeRunner([
+        (_is_gh_repo_view, _repo_view_ok()),
+        (_is_gh_api_refs_tags, _cp("not valid json", returncode=0)),
+    ])
+    monkeypatch.setattr("release.release.subprocess.run", runner)
+
+    ok, diag = _verify_remote_annotated_tag(
+        Path("/tmp/fake"), TAG_NAME, TARGET, MSG
+    )
+    assert not ok
+    assert "json" in diag.lower()
+
+
+# ----------------------------------------------------------------------
+# Scenario 10: gh repo view itself fails — fail-closed before any
+# tag check
+# ----------------------------------------------------------------------
+
+def test_repo_view_failure_aborts_early(monkeypatch):
+    runner = _FakeRunner([
+        (_is_gh_repo_view, _cp(
+            "", returncode=1, stderr="not authenticated"
+        )),
+    ])
+    monkeypatch.setattr("release.release.subprocess.run", runner)
+
+    ok, diag = _verify_remote_annotated_tag(
+        Path("/tmp/fake"), TAG_NAME, TARGET, MSG
+    )
+    assert not ok
+    assert "gh repo view" in diag.lower()
+    # And we never reached the tag-ref or tag-object calls
+    for call in runner.calls:
+        assert "git/refs/tags" not in (call[2] if len(call) > 2 else "")
+        assert "/git/tags/" not in (call[2] if len(call) > 2 else "")


### PR DESCRIPTION
## Summary

Fixes the rc-tag Step 5 remote-tag verification bug that caused the real `adafmt v1.0.0-rc3` invocation to abort into a partial-state recovery on 2026-06-12. The fix swaps the unreliable `git ls-remote` peeled-ref query for a GitHub Git Data API dereference.

## Bug

The previous Step 5 implementation used:

```
git ls-remote --tags origin refs/tags/<tag>
```

to read the peeled `^{}` line and compare it against the expected target commit. On GitHub's smart-HTTP protocol, an exact-ref refspec query returns **only the tag-object line** and omits the peeled-commit advertisement entirely. The git ref-discovery protocol allows this for exact-ref queries (the peeled-commit ref is optional). The script then misread the absence of `^{}` as "likely a lightweight tag" and aborted — even though the tag was a perfectly valid annotated tag, on the correct commit, with the correct message.

Observed on `adafmt v1.0.0-rc3` (tag `9f6628e33f718a1a51ebeabc766b9a3a13f7b809` -> `7567c5ef8587…`) — required manual recovery via a `gh release create --verify-tag` call, then a `gh run rerun --failed` of the upload job.

## Fix

New helper:

```python
_verify_remote_annotated_tag(project_root, tag_name,
                             expected_target_sha, expected_message)
    -> (ok: bool, diagnostic: str)
```

Uses two authoritative `gh api` calls:

1. `GET repos/{owner}/{repo}/git/refs/tags/<tag>`
   - confirms the ref exists
   - confirms `object.type == \"tag\"` (annotated; lightweight tags would report `\"commit\"` and are rejected)
2. `GET repos/{owner}/{repo}/git/tags/<tag-object-sha>`
   - confirms `object.type == \"commit\"`
   - confirms `object.sha == expected_target_sha`
   - confirms `message` matches `expected_message` (trailing-newline normalisation only)

The helper is side-effect-free and returns `(ok, diagnostic)` rather than printing — so it's unit-testable with `subprocess.run` mocked. Step 5 in `create_rc_release` becomes a single call to it plus existing print + partial-state remediation plumbing.

## Behaviour preserved

| Surface | Status |
|---|---|
| `prepare` / `release` / `validate` actions | byte-identical |
| rc-tag Steps 1, 2, 3, 4, 6, 7, 8, 9 | byte-identical |
| Step 5 `--dry-run` | surfaces what would be verified instead of the old ls-remote command |
| Partial-state remediation block on Step 5 failure | unchanged |
| Argparse choices + flag validation | unchanged |

## Tests — `tests/test_rc_tag_remote_tag_verification.py`

10 new tests mocking `subprocess.run`. Each scripts the response sequence `gh repo view` -> `gh api git/refs/tags` -> `gh api git/tags`:

| # | Test | Asserts |
|---|---|---|
| 1 | correct annotated remote tag accepted | `(ok=True, diag contains obj/target/msg)` |
| 2 | lightweight tag rejected | `ref.object.type == \"commit\"` is fatal |
| 3 | wrong target SHA rejected | mismatch surfaced in diagnostic |
| 4 | missing remote tag rejected | rc!=0 from `git/refs/tags` is fatal |
| 5 | **REGRESSION**: rc3-shaped tag verifies AND no `git ls-remote` call is made | proves the old failure mode cannot recur |
| 6 | wrong tag message rejected | mismatch surfaced |
| 7 | trailing-newline normalisation | matching message with `\\n` vs no-`\\n` accepted |
| 8 | multi-line tag message verbatim compare | internal blank lines preserved |
| 9 | malformed gh api JSON | fails closed with JSON parse error in diagnostic |
| 10 | `gh repo view` failure | aborts before any tag-API call |

### Test runs

```
$ python3 -m pytest tests/test_rc_tag_remote_tag_verification.py -v
============================== 10 passed in 0.02s ==============================

$ python3 -m pytest tests/ -q
150 passed in 0.73s
```

(140 -> 150 tests; 10 new, 0 regression.)

## Recommended Codex review scope

Narrow and focused — this is release-safety logic and a second pair of eyes is valuable:

1. **`_verify_remote_annotated_tag` correctness**: does the 5-check sequence (ref exists, ref.object.type == \"tag\", tag.object.type == \"commit\", tag.object.sha == expected, message matches) cover all observable misclassifications of a remote tag?
2. **Fail-closed discipline**: does every error path return `(False, diagnostic)` rather than degrading to a permissive default? (gh api non-zero rc, JSON parse failure, missing fields.)
3. **Step 5 wiring in `create_rc_release`**: does `--dry-run` still skip every mutation, and does the failure path still emit the correct `_emit_remediation_remote_tag_only` block?
4. **Test mocks**: are the response shapes realistic vs the real GitHub API for `git/refs/tags` and `git/tags`?
5. **Message normalisation**: is `rstrip('\\n')` on both sides the right level of tolerance, or should we also normalise CR/LF?

Out of scope for this PR (worth confirming, but not part of the fix):

- Other rc-tag steps' boundary discipline (covered in the original Codex review on `#16`).
- Steps 6–9's interaction with the new Step 5 — unchanged.

## Confirmation of scope

- Already-published `adafmt v1.0.0-rc3` not touched.
- No tags created, no Releases created, no workflows dispatched, no `alr publish`, no `adafmt` mutations, no issues / labels touched, no other repos touched.

## Test plan

- [ ] PR diff review on `release/release.py` (new helper + Step 5 call site) and `tests/test_rc_tag_remote_tag_verification.py` (new test file).
- [ ] Codex review per scope above.
- [ ] After merge: re-bump `adafmt scripts/python/shared` submodule pin to pick up the fix before any future RC or v1.0.0 final cut.

**Do not merge** until reviewed.